### PR TITLE
Sort sleep entries on screen by start date

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -3,6 +3,7 @@
 == master
 
 - Resolves: gh#21 daily average now detects completely skipped days
+- Resolves: gh#20 sleep entries are now being sorted in chronological order
 - Resolves: gh#16 support dark mode (martiandolphin)
 
 == 6.2

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepDao.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepDao.kt
@@ -20,7 +20,7 @@ import androidx.room.Update
 interface SleepDao {
     @Query("SELECT * FROM sleep ORDER BY sid ASC")
     suspend fun getAll(): List<Sleep>
-    @Query("SELECT * FROM sleep ORDER BY sid DESC")
+    @Query("SELECT * FROM sleep ORDER BY start_date DESC")
     fun getAllLive(): LiveData<List<Sleep>>
     @Query("SELECT * from sleep where sid = :id LIMIT 1")
     suspend fun getById(id: Int): Sleep


### PR DESCRIPTION
I ran all provided tests and they succeeded, but i assume that there weren't any tests checking for anything related anyway.

The `sid` is still used and displayed in the ActionBar of the "Sleep Details" pages, and i'm not sure how to go about this one since i don't have any use cases for it on my mind so i don't know who might be affected by this.
If anything, changing the behavior any further seems like taking away existing information about the order in which sleep entries were added.

This fixes #20