### PR TITLE
Sleep edit: use 24 hours view in the time picker according to system settings

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -4,7 +4,7 @@
 
 - Resolves: gh#21 daily average now detects completely skipped days
 - Resolves: gh#20 sleep entries are now being sorted in chronological order
-- Resolves: gh#19 use 24 hours view in the sleep edit time picker
+- Resolves: gh#19 in the sleep edit time picker, use 24 or 12 hour view according to system settings
 - Resolves: gh#16 support dark mode (martiandolphin)
 
 == 6.2

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
@@ -8,6 +8,7 @@ package hu.vmiklos.plees_tracker
 
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
+import android.text.format.DateFormat
 import android.widget.TextView
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -56,7 +57,7 @@ class SleepViewModel : ViewModel() {
                     }
                     updateSleep(activity, sleep)
                 }, dateTime[Calendar.HOUR_OF_DAY], dateTime[Calendar.MINUTE],
-                        /*is24HourView=*/true).show()
+                        /*is24HourView=*/DateFormat.is24HourFormat(activity)).show()
             }, dateTime[Calendar.YEAR], dateTime[Calendar.MONTH], dateTime[Calendar.DATE]).show()
         }
     }


### PR DESCRIPTION
Act according to the active locale or explicit user preference set in the android system settings.

Even though i very much like the idea of abolishing the 12h format completely, some people might beg to differ. Since there is a user settable preference in the android system anyway, it should be the least intrusive solution to honor these settings.

Improves upon <https://github.com/vmiklos/plees-tracker/issues/19>.