### PR TITLE
Speed up mass-import of sleeps

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Much faster mass-import of sleeps from a previous export result
+
 == 7.0.3
 
 - Resolves: gh#41 ability to export events to your calendar (Ed George)

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -407,7 +407,7 @@ class MainActivity : AppCompatActivity() {
         ).map(CalendarImport::mapEventToSleep)
 
         // Insert the list of Sleep into DB
-        viewModel.insertSleep(sleepList)
+        viewModel.insertSleeps(sleepList)
 
         Toast.makeText(
             this, getString(R.string.imported_items, sleepList.size), Toast.LENGTH_SHORT

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainViewModel.kt
@@ -48,9 +48,9 @@ class MainViewModel : ViewModel() {
         }
     }
 
-    fun insertSleep(sleepList: List<Sleep>) {
+    fun insertSleeps(sleepList: List<Sleep>) {
         viewModelScope.launch {
-            DataModel.insertSleep(sleepList)
+            DataModel.insertSleeps(sleepList)
         }
     }
 


### PR DESCRIPTION
I carefully tried to do streaming parsing to avoid OOM. But that means
the main activity's recycler view is updated after each & every view. I
don't have exact numbers, but the time for ~300 sleep goes from ~forever
to ~instant.

Change-Id: I388cbaa1189bbea7627674bb04fca7d460c3466d
