### PR TITLE
DataModel: use val because sleeps is never re-assigned

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -116,7 +116,7 @@ object DataModel {
         // memory: the benefit is that inserting all of them once triggers a single notification of
         // observers. This means that importing 100s of sleeps is still ~instant, while it used to
         // take ~forever.
-        var sleeps = mutableListOf<Sleep>()
+        val sleeps = mutableListOf<Sleep>()
         try {
             var first = true
             while (true) {


### PR DESCRIPTION
Change-Id: I420e88a3cd50dd4def13cbd0cc34ae87fd6e85cc
