### PR TITLE
Avoid vibration when the sleep notification is created

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Avoid vibration when the sleep notification is created
+
 == 7.0.4
 
 - Much faster mass-import of sleeps from a previous export result

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainService.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainService.kt
@@ -28,6 +28,11 @@ class MainService : Service() {
                 getString(R.string.notification_channel_name),
                 NotificationManager.IMPORTANCE_DEFAULT
             )
+
+            // Avoid unwanted vibration.
+            channel.vibrationPattern = longArrayOf(0)
+            channel.enableVibration(true)
+
             notificationManager.createNotificationChannel(channel)
         }
 


### PR DESCRIPTION
To be consistent with the clock app where the stopwatch/timer doesn't
vibrate, either.

See
<https://stackoverflow.com/questions/48261118/cannot-disable-notification-vibration-in-android-8/52207215#52207215>,
sadly need to uninstall the app to have this working (but that doesn't
remove the app data).

Change-Id: If6de618a90bbe48bb0f4f7396be436aa9f701dc0
