### PR TITLE
Add a setting to create automatic exports for backups

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,6 +6,7 @@
       <GradleProjectSettings>
         <option name="delegatedBuild" value="false" />
         <option name="testRunner" value="PLATFORM" />
+        <option name="disableWrapperSourceDistributionNotification" value="true" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -3,6 +3,8 @@
 == master
 
 - Avoid vibration when the sleep notification is created
+- Resolves: gh#32 ability to automatically backup to a storage folder, to be used with e.g.
+  Nextcloud
 
 == 7.0.4
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.documentfile:documentfile:1.0.1'
     testImplementation 'junit:junit:4.13'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -39,7 +39,9 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
  */
 object DataModel {
 
-    private lateinit var preferences: SharedPreferences
+    public lateinit var preferences: SharedPreferences
+
+    public var preferencesActivity: PreferencesActivity? = null
 
     var start: Date? = null
         set(start) {
@@ -162,7 +164,12 @@ object DataModel {
         CalendarExport.exportSleep(context, calendarId, sleeps)
     }
 
-    suspend fun exportDataToFile(context: Context, cr: ContentResolver, uri: Uri) {
+    suspend fun exportDataToFile(
+        context: Context,
+        cr: ContentResolver,
+        uri: Uri,
+        showToast: Boolean
+    ) {
         val sleeps = database.sleepDao().getAll()
 
         try {
@@ -195,6 +202,9 @@ object DataModel {
             }
         }
 
+        if (!showToast) {
+            return
+        }
         val text = context.getString(R.string.export_success)
         val duration = Toast.LENGTH_SHORT
         val toast = Toast.makeText(context, text, duration)

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.activity.result.contract.ActivityResultContracts.RequestMultiple
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.documentfile.provider.DocumentFile
 import androidx.lifecycle.ViewModelProvider
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.DefaultItemAnimator
@@ -47,6 +48,9 @@ import java.util.Calendar
 class MainActivity : AppCompatActivity() {
 
     private lateinit var viewModel: MainViewModel
+
+    // SharedPreferences keeps listeners in a WeakHashMap, so keep this as a member.
+    private val sharedPreferenceListener = SharedPreferencesChangeListener()
 
     private val exportPermissionLauncher = registerForActivityResult(
         RequestMultiplePermissions()
@@ -76,7 +80,9 @@ class MainActivity : AppCompatActivity() {
         registerForActivityResult(StartActivityForResult()) { result ->
             try {
                 result.data?.data?.let { uri ->
-                    viewModel.exportDataToFile(applicationContext, contentResolver, uri)
+                    viewModel.exportDataToFile(
+                        applicationContext, contentResolver, uri, showToast = true
+                    )
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "onActivityResult: exportData() failed")
@@ -120,13 +126,13 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val sharedPreferenceListener = SharedPreferencesChangeListener()
         sharedPreferenceListener.applyTheme(PreferenceManager.getDefaultSharedPreferences(this))
 
         viewModel = ViewModelProvider.NewInstanceFactory().create(MainViewModel::class.java)
 
         setContentView(R.layout.activity_main)
         val preferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+        preferences.registerOnSharedPreferenceChangeListener(sharedPreferenceListener)
         DataModel.init(applicationContext, preferences)
 
         val sleepsAdapter = SleepsAdapter(viewModel)
@@ -225,11 +231,40 @@ class MainActivity : AppCompatActivity() {
         if (DataModel.start != null && DataModel.stop == null) {
             DataModel.stop = Calendar.getInstance().time
             viewModel.stopSleep()
+            backupSleeps()
         } else {
             DataModel.start = Calendar.getInstance().time
             DataModel.stop = null
         }
         updateView()
+    }
+
+    private fun backupSleeps() {
+        val preferences = DataModel.preferences
+        val autoBackup = preferences.getBoolean("auto_backup", false)
+        val autoBackupPath = preferences.getString("auto_backup_path", "")
+        if (!autoBackup || autoBackupPath == null || autoBackupPath.isEmpty()) {
+            return
+        }
+
+        val folder = DocumentFile.fromTreeUri(applicationContext, Uri.parse(autoBackupPath))
+        if (folder == null) {
+            return
+        }
+
+        // Make sure that we don't create "backup (1).csv", etc.
+        val oldBackup = folder.findFile("backup.csv")
+        if (oldBackup != null && oldBackup.exists()) {
+            oldBackup.delete()
+        }
+
+        val backup = folder.createFile("text/csv", "backup.csv")
+        if (backup == null) {
+            return
+        }
+        viewModel.exportDataToFile(
+            applicationContext, contentResolver, backup.uri, showToast = false
+        )
     }
 
     private fun exportFileData() {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainViewModel.kt
@@ -24,9 +24,9 @@ class MainViewModel : ViewModel() {
         }
     }
 
-    fun exportDataToFile(context: Context, cr: ContentResolver, uri: Uri) {
+    fun exportDataToFile(context: Context, cr: ContentResolver, uri: Uri, showToast: Boolean) {
         viewModelScope.launch {
-            DataModel.exportDataToFile(context, cr, uri)
+            DataModel.exportDataToFile(context, cr, uri, showToast)
         }
     }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -6,10 +6,17 @@
 
 package hu.vmiklos.plees_tracker
 
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 
 class PreferencesActivity : AppCompatActivity() {
+    companion object {
+        private const val TAG = "PreferencesActivity"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         supportFragmentManager
@@ -17,6 +24,33 @@ class PreferencesActivity : AppCompatActivity() {
             .replace(R.id.settings_container, Preferences())
             .commit()
         setContentView(R.layout.settings)
+        DataModel.preferencesActivity = this
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        DataModel.preferencesActivity = null
+    }
+
+    private val backupActivityResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            try {
+                result.data?.data?.let { uri ->
+                    contentResolver.takePersistableUriPermission(
+                        uri, Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    )
+                    val editor = DataModel.preferences.edit()
+                    editor.putString("auto_backup_path", uri.toString())
+                    editor.apply()
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "onActivityResult: setting backup path failed")
+            }
+        }
+
+    public fun openFolderChooser() {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
+        backupActivityResult.launch(intent)
     }
 }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SharedPreferencesChangeListener.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SharedPreferencesChangeListener.kt
@@ -7,11 +7,36 @@
 package hu.vmiklos.plees_tracker
 
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 
-class SharedPreferencesChangeListener : SharedPreferences.OnSharedPreferenceChangeListener {
+class SharedPreferencesChangeListener() : SharedPreferences.OnSharedPreferenceChangeListener {
+    companion object {
+        private const val TAG = "SPChangeListener"
+    }
+
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-        sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+        if (key == "auto_backup") {
+            val autoBackup = sharedPreferences.getBoolean("auto_backup", false)
+            val autoBackupPath = sharedPreferences.getString("auto_backup_path", "")
+            if (autoBackup) {
+                if (autoBackupPath == null || autoBackupPath.isEmpty()) {
+                    val preferencesActivity = DataModel.preferencesActivity
+                    if (preferencesActivity != null) {
+                        Log.i(TAG, "onSharedPreferenceChanged: setting new backup path")
+                        preferencesActivity.openFolderChooser()
+                    }
+                }
+            } else {
+                // Forget old path, so it's possible to set a different one later.
+                Log.i(TAG, "onSharedPreferenceChanged: clearing old backup path")
+                val editor = DataModel.preferences.edit()
+                editor.remove("auto_backup_path")
+                editor.apply()
+            }
+            return
+        }
+
         applyTheme(sharedPreferences)
     }
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -47,4 +47,6 @@
     <string name="export_calendar_item">Exportar a Calendario</string>
     <string name="exported_event_description">Exportado de Plees Tracker</string>
     <string name="exported_items">Exportación completa</string>
+    <string name="settings_category_backup">Backup</string>
+    <string name="settings_automatic_backup">Automatic backup</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -47,4 +47,6 @@
     <string name="export_calendar_item">Exportar para Calendar</string>
     <string name="exported_event_description">Exportado do Plees Tracker</string>
     <string name="exported_items">Exportação completa</string>
+    <string name="settings_category_backup">Backup</string>
+    <string name="settings_automatic_backup">Automatic backup</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,4 +50,6 @@
     <string name="exported_event_description">Exported from Plees Tracker</string>
     <string name="exported_event_title" translatable="false">Plees Tracker Sleep</string>
     <string name="exported_items">Export complete</string>
+    <string name="settings_category_backup">Backup</string>
+    <string name="settings_automatic_backup">Automatic backup</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -15,5 +15,12 @@
             android:title="@string/settings_enable_dark_theme" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/settings_category_backup">
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="auto_backup"
+            android:title="@string/settings_automatic_backup" />
+    </PreferenceCategory>
+
 </PreferenceScreen>
 


### PR DESCRIPTION
The setting is off by default.

Once it's on, the user can choose a folder. The backup.csv in that
folder is updated each time a sleep is stopped. Keep it simple like like
for now, we could later limit this to "once a week", if it's needed.

Fixes <https://github.com/vmiklos/plees-tracker/issues/32>.

Change-Id: I341b3ce1dbdf29b4c4a73b8f4015fda4b1d132e5
