### PR TITLE
backup: take RW permission, not just W

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -34,10 +34,13 @@ class PreferencesActivity : AppCompatActivity() {
 
     private val backupActivityResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                Intent.FLAG_GRANT_WRITE_URI_PERMISSION
             try {
                 result.data?.data?.let { uri ->
                     contentResolver.takePersistableUriPermission(
-                        uri, Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                        uri,
+                        flags
                     )
                     val editor = DataModel.preferences.edit()
                     editor.putString("auto_backup_path", uri.toString())


### PR DESCRIPTION
We are reading when we check if the backup is already there.

Change-Id: Ic22c6fdf6060236495e74c57babcb34c42ceeafd
