### PR TITLE
PreferencesActivity: disable autobackup bool when path is empty

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,10 @@
 = Version descriptions
 
+== master
+
+- Resolves gh#90 disable auto-backup bool setting when the user refuses to pick an auto-backup
+  folder
+
 == 7.0.5
 
 - Avoid vibration when the sleep notification is created

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
@@ -7,11 +7,18 @@
 package hu.vmiklos.plees_tracker
 
 import android.os.Bundle
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 
 class Preferences : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
+        val autoBackupPath = findPreference<Preference>("auto_backup_path")
+        autoBackupPath?.let {
+            val preferences = DataModel.preferences
+            val path = preferences.getString("auto_backup_path", "")
+            it.summary = path
+        }
     }
 }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -34,6 +34,7 @@ class PreferencesActivity : AppCompatActivity() {
 
     private val backupActivityResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            var success = false
             val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
                 Intent.FLAG_GRANT_WRITE_URI_PERMISSION
             try {
@@ -45,7 +46,21 @@ class PreferencesActivity : AppCompatActivity() {
                     val editor = DataModel.preferences.edit()
                     editor.putString("auto_backup_path", uri.toString())
                     editor.apply()
+                    success = true
                 }
+
+                if (!success) {
+                    // Disable the bool setting when the user picked no folder.
+                    val editor = DataModel.preferences.edit()
+                    editor.putBoolean("auto_backup", false)
+                    editor.apply()
+                }
+
+                // Refresh the view in case auto_backup or auto_backup_path changed.
+                supportFragmentManager
+                    .beginTransaction()
+                    .replace(R.id.settings_container, Preferences())
+                    .commit()
             } catch (e: Exception) {
                 Log.e(TAG, "onActivityResult: setting backup path failed")
             }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -49,4 +49,5 @@
     <string name="exported_items">Exportación completa</string>
     <string name="settings_category_backup">Backup</string>
     <string name="settings_automatic_backup">Automatic backup</string>
+    <string name="settings_backup_path">Backup path</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -49,4 +49,5 @@
     <string name="exported_items">Exportação completa</string>
     <string name="settings_category_backup">Backup</string>
     <string name="settings_automatic_backup">Backup automático</string>
+    <string name="settings_backup_path">Backup path</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,4 +52,5 @@
     <string name="exported_items">Export complete</string>
     <string name="settings_category_backup">Backup</string>
     <string name="settings_automatic_backup">Automatic backup</string>
+    <string name="settings_backup_path">Backup path</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -20,6 +20,9 @@
             android:defaultValue="false"
             android:key="auto_backup"
             android:title="@string/settings_automatic_backup" />
+        <Preference
+            android:key="auto_backup_path"
+            android:title="@string/settings_backup_path"/>
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
And show the value of the backup path. Add explicit code to update it
not only when the settings activity is restarted, but also when
auto-backup is enabled.

Fixes <https://github.com/vmiklos/plees-tracker/issues/90>.

Change-Id: Ib4ac8d3e4402c8eb9d54d1c38fdfdcba99bc17dc
