### PR TITLE
Feat sleep time

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -216,6 +216,10 @@ class MainActivity : AppCompatActivity() {
         super.onStart()
         val intent = Intent(this, MainService::class.java)
         stopService(intent)
+        val recyclerView = findViewById<RecyclerView>(R.id.sleeps)
+        recyclerView.findViewHolderForAdapterPosition(0)?.let {
+            recyclerView.adapter!!.onBindViewHolder(it, 0)
+        }
     }
 
     override fun onStop() {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -218,7 +218,10 @@ class MainActivity : AppCompatActivity() {
         stopService(intent)
         val recyclerView = findViewById<RecyclerView>(R.id.sleeps)
         recyclerView.findViewHolderForAdapterPosition(0)?.let {
-            recyclerView.adapter!!.onBindViewHolder(it, 0)
+            // Since the adapter unconditionally gets assigned in `onCreate()`
+            // it shouldn't be necessary to consider fixing it here.
+            // If it is null at this point a lot more must have gone wrong as well.
+            recyclerView.adapter?.onBindViewHolder(it, 0)
         }
     }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepsAdapter.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepsAdapter.kt
@@ -84,9 +84,11 @@ class SleepsAdapter(
         val durationMS = sleep.stop - sleep.start
         val durationText = DataModel.formatDuration(durationMS / 1000)
         holder.duration.text = durationText
-        val nextSleepReferenceTime =
-                if (position == 0) System.currentTimeMillis()
-                else data[position - 1].start
+        val nextSleepReferenceTime = if (position == 0) {
+                    System.currentTimeMillis()
+                } else {
+                    data[position - 1].start
+                }
         val durationWakeMS = nextSleepReferenceTime - sleep.stop;
         val durationWakeText = DataModel.formatDuration(durationWakeMS / 1000)
         holder.durationWake.text = durationWakeText

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepsAdapter.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepsAdapter.kt
@@ -84,6 +84,12 @@ class SleepsAdapter(
         val durationMS = sleep.stop - sleep.start
         val durationText = DataModel.formatDuration(durationMS / 1000)
         holder.duration.text = durationText
+        val nextSleepReferenceTime =
+                if (position == 0) System.currentTimeMillis()
+                else data[position - 1].start
+        val durationWakeMS = nextSleepReferenceTime - sleep.stop;
+        val durationWakeText = DataModel.formatDuration(durationWakeMS / 1000)
+        holder.durationWake.text = durationWakeText
         holder.rating.rating = sleep.rating.toFloat()
         holder.rating.onRatingBarChangeListener = SleepRateCallback(viewModel, sleep)
     }
@@ -95,6 +101,7 @@ class SleepsAdapter(
         val start: TextView = view.findViewById(R.id.sleep_item_start)
         val stop: TextView = view.findViewById(R.id.sleep_item_stop)
         val duration: TextView = view.findViewById(R.id.sleep_item_duration)
+        val durationWake: TextView = view.findViewById(R.id.wake_item_duration)
         val rating: RatingBar = view.findViewById(R.id.sleep_item_rating)
     }
 }

--- a/app/src/main/res/layout/layout_sleep_item.xml
+++ b/app/src/main/res/layout/layout_sleep_item.xml
@@ -121,6 +121,41 @@
             tools:text="05:20" />
 
 
+        <ImageView
+            android:id="@+id/wake_time_image"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="10dp"
+            android:src="@drawable/ic_play_green"
+            app:layout_constraintTop_toBottomOf="@id/sleep_time_image"
+            app:layout_constraintStart_toStartOf="parent"
+            android:contentDescription="@string/awake_for_label" />
+
+        <TextView
+            android:id="@+id/wake_time_header"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@string/awake_for_label"
+            android:textSize="16sp"
+            app:layout_constraintTop_toTopOf="@id/wake_time_image"
+            app:layout_constraintTop_toBottomOf="@id/wake_time_image"
+            app:layout_constraintStart_toEndOf="@id/wake_time_image" />
+
+
+        <TextView
+            android:id="@+id/wake_item_duration"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="10dp"
+            android:textSize="16sp"
+            app:layout_constraintTop_toTopOf="@id/wake_time_image"
+            app:layout_constraintTop_toBottomOf="@id/wake_time_image"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="18:40" />
+
+
         <RatingBar
             android:id="@+id/sleep_item_rating"
             android:layout_width="wrap_content"
@@ -131,7 +166,7 @@
             android:numStars="5"
             android:stepSize="1"
             android:rating="0"
-            app:layout_constraintTop_toBottomOf="@+id/sleep_time_image"
+            app:layout_constraintTop_toBottomOf="@id/wake_time_image"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"/>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7,6 +7,7 @@
     <string name="stopped_on">Terminó en</string>
     <string name="started_on">Empezó en</string>
     <string name="slept_for_label">Dormir para</string>
+    <string name="awake_for_label">Despierto para</string>
     <string name="sleeps">Dormidas</string>
     <string name="status">Estado</string>
     <string name="export_file_item">Exportación de archivos</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -7,6 +7,7 @@
     <string name="stopped_on">Parou em</string>
     <string name="started_on">Iniciou em</string>
     <string name="slept_for_label">Dormiu por</string>
+    <string name="awake_for_label">Acordou atrás</string>
     <string name="sleeps">Sonos</string>
     <string name="status">Status</string>
     <string name="export_file_item">Exportar para um arquivo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="stopped_on">Stopped on</string>
     <string name="started_on">Started on</string>
     <string name="slept_for_label">Slept for</string>
+    <string name="awake_for_label">Awake for</string>
     <string name="sleeps">Sleeps</string>
     <string name="status">Status</string>
     <string name="import_file_item">Import File</string>


### PR DESCRIPTION
Implemented this a while ago for myself and i find it pretty useful.

As this grows each sleep entry even more it might be time to add a preference to toggle each row as desired. At least i personally don't use the rating bar and tweaked it out of the UI in my personal build to get more space.

Currently in this PR:
- [x] The feature itself
- [x] Translations (`default`, `es`, `pt-BR`)
- [ ] Changelog entry
- [ ] Distinct icon for the `Awake for` sleep entry row
- [ ] Fixed tests that were broken by this feature
- [ ] Tests

Re: Tests - I have no experience in this area and don't feel confident to write tests for this, especially if i try to imagine how one would assert values that are supposed to change with second-precision.