### PR TITLE
CI: deliver just the release apk, not the other two apks

### DIFF
--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -14,6 +14,6 @@
 ./gradlew connectedAndroidTest
 
 mkdir dist
-cp $(find . -name *.apk) dist/
+cp app/build/outputs/apk/release/app-release-unsigned.apk dist/
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
Which are less interesting.

Change-Id: I64fbbbc89b286b2eaddc6b8f5969bd76d33eeedc
