### PR TITLE
Add a widget to immediately start/stop tracking

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Reolsves gh#92 add a widget to start/stop tracking with a single stap from the home screen
+
 == 7.1.0
 
 - Resolves gh#90 disable auto-backup bool setting when the user refuses to pick an auto-backup

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,9 @@ android {
     buildFeatures {
         viewBinding true
     }
+    lintOptions {
+        disable 'MissingTranslation'
+    }
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,17 @@
         </activity>
         <activity android:name=".PreferencesActivity" />
         <service android:name=".MainService"/>
+        <receiver
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/widget_start_stop"
+            android:name=".ToggleWidget">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_info_toggle" />
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -209,6 +209,13 @@ class MainActivity : AppCompatActivity() {
             recyclerView.setOnScrollChangeListener(listener)
         }
 
+        // See if the activity is triggered from the widget. If so, toggle the start/stop state.
+        intent?.let {
+            if (it.getBooleanExtra("startStop", false)) {
+                startStop(findViewById(R.id.start_stop))
+            }
+        }
+
         updateView()
     }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/ToggleWidget.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/ToggleWidget.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Miklos Vajna. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package hu.vmiklos.plees_tracker
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.content.Intent
+import android.widget.RemoteViews
+
+/**
+ * Provides a widget that opens the main activity and immediately toggles between started/stopped
+ * sleep tracking.
+ */
+class ToggleWidget : AppWidgetProvider() {
+    override fun onUpdate(
+        context: Context?,
+        appWidgetManager: AppWidgetManager?,
+        appWidgetIds: IntArray?
+    ) {
+        for (appWidgetId in appWidgetIds!!) {
+            val intent = Intent(context, MainActivity::class.java)
+            intent.putExtra("startStop", true)
+            val pendingIntent = PendingIntent.getActivity(
+                context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT
+            )
+            val remoteViews = RemoteViews(context!!.packageName, R.layout.widget_layout_toggle)
+            remoteViews.setOnClickPendingIntent(R.id.widget_toggle, pendingIntent)
+            appWidgetManager!!.updateAppWidget(appWidgetId, remoteViews)
+        }
+    }
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/app/src/main/res/layout/widget_layout_toggle.xml
+++ b/app/src/main/res/layout/widget_layout_toggle.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal" >
+
+    <ImageView
+        android:id="@+id/widget_toggle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:src="@mipmap/ic_launcher"/>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,4 +54,5 @@
     <string name="settings_category_backup">Backup</string>
     <string name="settings_automatic_backup">Automatic backup</string>
     <string name="settings_backup_path">Backup path</string>
+    <string name="widget_start_stop">Toggle tracking</string>
 </resources>

--- a/app/src/main/res/xml/widget_info_toggle.xml
+++ b/app/src/main/res/xml/widget_info_toggle.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
+    android:initialLayout="@layout/widget_layout_toggle"
+    android:widgetCategory="home_screen"
+    >
+</appwidget-provider>


### PR DESCRIPTION
Given that this is something the user does twice a day, it makes sense
to have a single-tap action for this, instead of the two-taps to start
the main activity + press the start/stop button.

Fixes <https://github.com/vmiklos/plees-tracker/issues/92>.

Change-Id: I7acd4d1116210050beee1f4553075883fb544161
