### PR TITLE
Add dashboard duration setting

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -111,6 +111,10 @@ object DataModel {
         return database.sleepDao().getById(sid)
     }
 
+    fun getSleepsAfterLive(after: Date): LiveData<List<Sleep>> {
+        return database.sleepDao().getAfterLive(after.time)
+    }
+
     suspend fun importData(context: Context, cr: ContentResolver, uri: Uri) {
         val inputStream = cr.openInputStream(uri)
         val br = BufferedReader(InputStreamReader(inputStream))
@@ -269,11 +273,6 @@ object DataModel {
             }
         }
 
-        var sum: Long = 0
-        for (value in sums.values) {
-            sum += value
-        }
-
         if (sums.size == 0) {
             return ""
         }
@@ -282,7 +281,7 @@ object DataModel {
         // can be more, in case a whole 24h period was left out.
         val msPerDay = 86400 * 1000
         val count = (maxKey - minKey) / msPerDay + 1
-        return formatDuration(sum / count)
+        return formatDuration(sums.values.sum() / count)
     }
 
     fun formatDuration(seconds: Long): String {
@@ -302,13 +301,7 @@ object DataModel {
      * Returns the subset of [sleeps] which stop after [after].
      */
     fun filterSleeps(sleeps: List<Sleep>, after: Date): List<Sleep> {
-        val ret = mutableListOf<Sleep>()
-        for (sleep in sleeps) {
-            if (sleep.stop > after.time) {
-                ret.add(sleep)
-            }
-        }
-        return ret
+        return sleeps.filter { it.stop > after.time }
     }
 }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SharedPreferencesLiveData.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SharedPreferencesLiveData.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Miklos Vajna. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package hu.vmiklos.plees_tracker
+
+import android.content.SharedPreferences
+import androidx.lifecycle.LiveData
+
+/**
+ * From https://gist.github.com/rharter/1df1cd72ce4e9d1801bd2d49f2a96810#gistcomment-3541759
+ */
+private class SharedPreferenceLiveData<T>(
+    private val sharedPrefs: SharedPreferences,
+    private val key: String,
+    private val getPreferenceValue: () -> T,
+) : LiveData<T>(getPreferenceValue()), SharedPreferences.OnSharedPreferenceChangeListener {
+    override fun onActive() {
+        sharedPrefs.registerOnSharedPreferenceChangeListener(this)
+        updateIfChanged()
+    }
+
+    override fun onInactive() = sharedPrefs.unregisterOnSharedPreferenceChangeListener(this)
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
+        if (key == this.key || key == null) {
+            // Note that we get here on every preference write, even if the value has not changed
+            updateIfChanged()
+        }
+    }
+
+    /** Update the live data value, but only if the value has changed. */
+    private fun updateIfChanged() = with(getPreferenceValue()) { if (value != this) value = this }
+}
+
+fun SharedPreferences.liveData(key: String, default: Int): LiveData<Int> =
+    SharedPreferenceLiveData(this, key) { getInt(key, default) }
+
+fun SharedPreferences.liveData(key: String, default: Long): LiveData<Long> =
+    SharedPreferenceLiveData(this, key) { getLong(key, default) }
+
+fun SharedPreferences.liveData(key: String, default: Boolean): LiveData<Boolean> =
+    SharedPreferenceLiveData(this, key) { getBoolean(key, default) }
+
+fun SharedPreferences.liveData(key: String, default: Float): LiveData<Float> =
+    SharedPreferenceLiveData(this, key) { getFloat(key, default) }
+
+fun SharedPreferences.liveData(key: String, default: String?): LiveData<String?> =
+    SharedPreferenceLiveData(this, key) { getString(key, default) }
+
+fun SharedPreferences.liveData(key: String, default: Set<String>?): LiveData<Set<String>?> =
+    SharedPreferenceLiveData(this, key) { getStringSet(key, default) }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepDao.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepDao.kt
@@ -24,6 +24,8 @@ interface SleepDao {
     fun getAllLive(): LiveData<List<Sleep>>
     @Query("SELECT * from sleep where sid = :id LIMIT 1")
     suspend fun getById(id: Int): Sleep
+    @Query("SELECT * FROM sleep WHERE stop_date > :after ORDER BY start_date DESC")
+    fun getAfterLive(after: Long): LiveData<List<Sleep>>
 
     @Insert
     suspend fun insert(sleepList: List<Sleep>)

--- a/app/src/main/java/hu/vmiklos/plees_tracker/StatsActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/StatsActivity.kt
@@ -9,6 +9,7 @@ package hu.vmiklos.plees_tracker
 import android.os.Bundle
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import java.util.Calendar
 
 /**
@@ -32,47 +33,50 @@ class StatsActivity : AppCompatActivity() {
                 if (sleeps != null) {
                     val fragments = supportFragmentManager
 
-                    // Last 7 days
-                    val sevenDaysAgo = Calendar.getInstance()
-                    sevenDaysAgo.add(Calendar.DATE, -7)
-                    val last7days = DataModel.filterSleeps(sleeps, sevenDaysAgo.time)
+                    // Last week
+                    val lastWeek = Calendar.getInstance()
+                    lastWeek.add(Calendar.DATE, -7)
+                    val lastWeekSleeps = DataModel.filterSleeps(sleeps, lastWeek.time)
+                    val lastWeekFragment = fragments.findFragmentById(R.id.last_week_body)
+                    populateFragment(lastWeekFragment, lastWeekSleeps)
 
-                    val last7daysFragment = fragments.findFragmentById(R.id.last7days_body)?.view
-                    var count = last7daysFragment?.findViewById<TextView>(
-                        R.id.fragment_stats_sleeps
-                    )
-                    count?.text = DataModel.getSleepCountStat(last7days)
-                    var average = last7daysFragment?.findViewById<TextView>(
-                        R.id.fragment_stats_average
-                    )
-                    average?.text = DataModel.getSleepDurationStat(last7days)
-                    var daily = last7daysFragment?.findViewById<TextView>(R.id.fragment_stats_daily)
-                    daily?.text = DataModel.getSleepDurationDailyStat(last7days)
+                    // Last two weeks
+                    val lastTwoWeeks = Calendar.getInstance()
+                    lastTwoWeeks.add(Calendar.DATE, -14)
+                    val lastTwoWeekSleeps = DataModel.filterSleeps(sleeps, lastTwoWeeks.time)
+                    val lastTwoWeeksFragment = fragments.findFragmentById(R.id.last_two_weeks_body)
+                    populateFragment(lastTwoWeeksFragment, lastTwoWeekSleeps)
 
-                    // This year
-                    val startOfYear = Calendar.getInstance()
-                    startOfYear.set(Calendar.DAY_OF_YEAR, 1)
-                    val thisYear = DataModel.filterSleeps(sleeps, startOfYear.time)
+                    // Last month
+                    val lastMonth = Calendar.getInstance()
+                    lastMonth.add(Calendar.DATE, -30)
+                    val lastMonthSleeps = DataModel.filterSleeps(sleeps, lastMonth.time)
+                    val lastMonthFragments = fragments.findFragmentById(R.id.last_month_body)
+                    populateFragment(lastMonthFragments, lastMonthSleeps)
 
-                    val thisyearFragment = fragments.findFragmentById(R.id.thisyear_body)?.view
-                    count = thisyearFragment?.findViewById(R.id.fragment_stats_sleeps)
-                    count?.text = DataModel.getSleepCountStat(thisYear)
-                    average = thisyearFragment?.findViewById(R.id.fragment_stats_average)
-                    average?.text = DataModel.getSleepDurationStat(thisYear)
-                    daily = thisyearFragment?.findViewById(R.id.fragment_stats_daily)
-                    daily?.text = DataModel.getSleepDurationDailyStat(thisYear)
+                    // Last year
+                    val lastYear = Calendar.getInstance()
+                    lastYear.add(Calendar.DATE, -365)
+                    val lastYearSleeps = DataModel.filterSleeps(sleeps, lastYear.time)
+                    val lastYearFragment = fragments.findFragmentById(R.id.last_year_body)
+                    populateFragment(lastYearFragment, lastYearSleeps)
 
                     // All time, i.e. no filter
-                    val alltimeFragment = fragments.findFragmentById(R.id.alltime_body)?.view
-                    count = alltimeFragment?.findViewById(R.id.fragment_stats_sleeps)
-                    count?.text = DataModel.getSleepCountStat(sleeps)
-                    average = alltimeFragment?.findViewById(R.id.fragment_stats_average)
-                    average?.text = DataModel.getSleepDurationStat(sleeps)
-                    daily = alltimeFragment?.findViewById(R.id.fragment_stats_daily)
-                    daily?.text = DataModel.getSleepDurationDailyStat(sleeps)
+                    val allTimeFragment = fragments.findFragmentById(R.id.all_time_body)
+                    populateFragment(allTimeFragment, sleeps)
                 }
             }
         )
+    }
+
+    private fun populateFragment(fragment: Fragment?, sleeps: List<Sleep>) {
+        val view = fragment?.view
+        val count = view?.findViewById<TextView>(R.id.fragment_stats_sleeps)
+        count?.text = DataModel.getSleepCountStat(sleeps)
+        val average = view?.findViewById<TextView>(R.id.fragment_stats_average)
+        average?.text = DataModel.getSleepDurationStat(sleeps)
+        val daily = view?.findViewById<TextView>(R.id.fragment_stats_daily)
+        daily?.text = DataModel.getSleepDurationDailyStat(sleeps)
     }
 }
 

--- a/app/src/main/res/layout/activity_stats.xml
+++ b/app/src/main/res/layout/activity_stats.xml
@@ -23,51 +23,95 @@
                 android:layout_height="match_parent">
 
                 <TextView
-                    android:id="@+id/last7days_header"
+                    android:id="@+id/last_week_header"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="10dp"
                     android:textStyle="bold"
-                    android:text="@string/last7days"
+                    android:text="@string/last_week"
                     android:textColor="@color/textColor"
                     android:textSize="20sp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <androidx.fragment.app.FragmentContainerView
-                    android:id="@+id/last7days_body"
+                    android:id="@+id/last_week_body"
                     android:name="hu.vmiklos.plees_tracker.StatsFragment"
                     android:layout_width="match_parent"
                     android:layout_height="130dp"
                     android:orientation="horizontal"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/last7days_header" />
+                    app:layout_constraintTop_toBottomOf="@+id/last_week_header" />
 
                 <TextView
-                    android:id="@+id/thisyear_header"
+                    android:id="@+id/last_two_weeks_header"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="10dp"
                     android:textStyle="bold"
-                    android:text="@string/this_year"
+                    android:text="@string/last_two_weeks"
                     android:textColor="@color/textColor"
                     android:textSize="20sp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/last7days_body" />
+                    app:layout_constraintTop_toBottomOf="@+id/last_week_body" />
 
                 <androidx.fragment.app.FragmentContainerView
-                    android:id="@+id/thisyear_body"
+                    android:id="@+id/last_two_weeks_body"
                     android:name="hu.vmiklos.plees_tracker.StatsFragment"
                     android:layout_width="match_parent"
                     android:layout_height="130dp"
                     android:orientation="horizontal"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/thisyear_header" />
+                    app:layout_constraintTop_toBottomOf="@+id/last_two_weeks_header" />
 
                 <TextView
-                    android:id="@+id/alltime_header"
+                    android:id="@+id/last_month_header"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_marginTop="10dp"
+                    android:textStyle="bold"
+                    android:text="@string/last_month"
+                    android:textColor="@color/textColor"
+                    android:textSize="20sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/last_two_weeks_body" />
+
+                <androidx.fragment.app.FragmentContainerView
+                    android:id="@+id/last_month_body"
+                    android:name="hu.vmiklos.plees_tracker.StatsFragment"
+                    android:layout_width="match_parent"
+                    android:layout_height="130dp"
+                    android:orientation="horizontal"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/last_month_header" />
+
+                <TextView
+                    android:id="@+id/last_year_header"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:layout_marginTop="10dp"
+                    android:textStyle="bold"
+                    android:text="@string/last_year"
+                    android:textColor="@color/textColor"
+                    android:textSize="20sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/last_month_body" />
+
+                <androidx.fragment.app.FragmentContainerView
+                    android:id="@+id/last_year_body"
+                    android:name="hu.vmiklos.plees_tracker.StatsFragment"
+                    android:layout_width="match_parent"
+                    android:layout_height="130dp"
+                    android:orientation="horizontal"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/last_year_header" />
+
+                <TextView
+                    android:id="@+id/all_time_header"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="10dp"
@@ -77,16 +121,16 @@
                     android:textColor="@color/textColor"
                     android:textSize="20sp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/thisyear_body" />
+                    app:layout_constraintTop_toBottomOf="@+id/last_year_body" />
 
                 <androidx.fragment.app.FragmentContainerView
-                    android:id="@+id/alltime_body"
+                    android:id="@+id/all_time_body"
                     android:name="hu.vmiklos.plees_tracker.StatsFragment"
                     android:layout_width="match_parent"
                     android:layout_height="130dp"
                     android:orientation="horizontal"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/alltime_header" />
+                    app:layout_constraintTop_toBottomOf="@+id/all_time_header" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.appbar.CollapsingToolbarLayout>
     </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/fragment_stats.xml
+++ b/app/src/main/res/layout/fragment_stats.xml
@@ -2,12 +2,12 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/last7days_body"
+    android:id="@+id/last_week_body"
     android:layout_width="match_parent"
     android:layout_height="130dp"
     android:orientation="horizontal"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/last7days_header">
+    app:layout_constraintTop_toBottomOf="@+id/last_week_header">
 
     <LinearLayout
         android:layout_width="0dp"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -25,15 +25,12 @@
     <string name="website">Sitio web</string>
     <string name="average_string">Promedio</string>
     <string name="daily_average_string">Diario</string>
-    <string name="dashboard">Control</string>
+    <string name="dashboard">Control (%s)</string>
     <string name="sleep_details">Detalles del sueño</string>
     <string name="settings">Ajustes</string>
     <string name="settings_category_theme">Tema (requeriría reiniciar)</string>
     <string name="settings_follow_system_theme">Seguir tema del sistema</string>
     <string name="settings_enable_dark_theme">Modo oscuro</string>
-    <string name="last7days">Últimos 7 días</string>
-    <string name="this_year">Este año</string>
-    <string name="all_time">Todo el tiempo</string>
     <string name="stats">Estadísticas</string>
     <string name="notification_channel_name">Notificaciones del rastreo</string>
     <string name="import_file_item">Importar archivo</string>
@@ -51,4 +48,11 @@
     <string name="settings_category_backup">Respaldo</string>
     <string name="settings_automatic_backup">Respaldo automático</string>
     <string name="settings_backup_path">Ruta de respaldo</string>
+    <string name="settings_category_dashboard">Dashboard</string>
+    <string name="settings_dashboard_duration">Duration</string>
+    <string name="last_week">Last week</string>
+    <string name="last_two_weeks">Last two weeks</string>
+    <string name="last_month">Last month</string>
+    <string name="last_year">Last year</string>
+    <string name="all_time">Todo el tiempo</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -25,15 +25,12 @@
     <string name="website">Site</string>
     <string name="average_string">Média</string>
     <string name="daily_average_string">Diariamente</string>
-    <string name="dashboard">Painel</string>
+    <string name="dashboard">Painel (%s)</string>
     <string name="sleep_details">Detalhes do sono</string>
     <string name="settings">Configurações</string>
     <string name="settings_category_theme">Tema (É necessário reiniciar)</string>
     <string name="settings_follow_system_theme">Seguir o tema do sistema</string>
     <string name="settings_enable_dark_theme">Modo escuro</string>
-    <string name="last7days">Últimos 7 dias</string>
-    <string name="this_year">Este ano</string>
-    <string name="all_time">Todo o tempo</string>
     <string name="stats">Estatísticas</string>
     <string name="notification_channel_name">Notificações de rastreamento</string>
     <string name="import_file_item">Importar arquivo</string>
@@ -51,4 +48,11 @@
     <string name="settings_category_backup">Backup</string>
     <string name="settings_automatic_backup">Backup automático</string>
     <string name="settings_backup_path">Local do backup</string>
+    <string name="settings_category_dashboard">Dashboard</string>
+    <string name="settings_dashboard_duration">Duration</string>
+    <string name="last_week">Last week</string>
+    <string name="last_two_weeks">Last two weeks</string>
+    <string name="last_month">Last month</string>
+    <string name="last_year">Last year</string>
+    <string name="all_time">Todo o tempo</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,15 +30,12 @@
     <string name="website">Website</string>
     <string name="average_string">Average</string>
     <string name="daily_average_string">Daily</string>
-    <string name="dashboard">Dashboard</string>
+    <string name="dashboard">Dashboard (%s)</string>
     <string name="sleep_details">Sleep Details</string>
     <string name="settings">Settings</string>
     <string name="settings_category_theme">Theme (May Require Restart)</string>
     <string name="settings_follow_system_theme">Follow System Theme</string>
     <string name="settings_enable_dark_theme">Dark Mode</string>
-    <string name="last7days">Last 7 days</string>
-    <string name="this_year">This year</string>
-    <string name="all_time">All time</string>
     <string name="stats">Statistics</string>
     <string name="notification_channel_name">Tracker notifications</string>
     <string name="select_calendar_dialog_title">Select Calendar</string>
@@ -55,4 +52,25 @@
     <string name="settings_automatic_backup">Automatic backup</string>
     <string name="settings_backup_path">Backup path</string>
     <string name="widget_start_stop">Toggle tracking</string>
+    <string name="settings_category_dashboard">Dashboard</string>
+    <string name="settings_dashboard_duration">Duration</string>
+    <string name="last_week">Last week</string>
+    <string name="last_two_weeks">Last two weeks</string>
+    <string name="last_month">Last month</string>
+    <string name="last_year">Last year</string>
+    <string name="all_time">All time</string>
+    <string-array name="duration_entries">
+        <item>@string/last_week</item>
+        <item>@string/last_two_weeks</item>
+        <item>@string/last_month</item>
+        <item>@string/last_year</item>
+        <item>@string/all_time</item>
+    </string-array>
+    <string-array name="duration_entry_values">
+        <item>"-7"</item>
+        <item>"-14"</item>
+        <item>"-30"</item>
+        <item>"-365"</item>
+        <item>"0"</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -22,7 +22,17 @@
             android:title="@string/settings_automatic_backup" />
         <Preference
             android:key="auto_backup_path"
-            android:title="@string/settings_backup_path"/>
+            android:title="@string/settings_backup_path" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_category_dashboard">
+        <ListPreference
+            android:key="dashboard_duration"
+            android:title="@string/settings_dashboard_duration"
+            android:entries="@array/duration_entries"
+            android:entryValues="@array/duration_entry_values"
+            android:defaultValue="0"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -8,20 +8,22 @@ simple: causing no battery drain, nor any privacy problems.
 
 This activity allows:
 
-- Seeing the status of the tracking: not yet started, in progress and finished
+- Seeing the status of the tracking: not yet started, in progress and finished.
 
 - Dashboard: the number of all tracked sleeps, average of sleep durations and a daily average (in
-  case you sleep multiple times a day or you sometimes skip a whole day).
+  case you sleep multiple times a day or you sometimes skip a whole day) for a customizable
+  duration (see the preferences activity below).
 
-- A list of past sleeps: start/stop time for each sleep, awake time and duration counted from these
-  and a rating you can manually specify after the tracking stopped. The awake time of the latest
-  sleep depends on the current time, so it'll increase if you restart plees-tracker.
+- A list of past sleeps for the chosen duration: start/stop time for each sleep, awake time and
+  duration counted from these and a rating you can manually specify after the tracking stopped.
+  The awake time of the latest sleep depends on the current time, so it'll increase if you restart
+  plees-tracker.
 
 - Swiping a sleep left/right will remove the sleep.
 
 - Tapping on a sleep allows getting to a dedicated sleep activity for a single sleep.
 
-- A floating action bottom at the bottom right corner allows to actually start / stop the tracking.
+- A floating action button at the bottom right corner allows to actually start / stop the tracking.
 
 The menu of this activity allows:
 
@@ -47,6 +49,9 @@ Backup settings allow you to automatically back up your sleeps after a tracking 
 useful in case you selected a path which is then implicitly synchronized to some external server,
 e.g. Nextcloud.
 
+You can also customize the dashboard duration, which limits the sleeps and sleep statistics on the
+dashboard to the time period selected in the main activity.
+
 == Sleep activity
 
 The sleep activity allows modifying the start or stop time of a single recorded sleep, which is
@@ -54,12 +59,17 @@ useful if you want to update the recorded timestamps to better match reality.
 
 == Stats activity
 
-The main activity considers all sleeps when counting the sleeps or when calculating the 2 kind of
-averages for your sleeps. The stats activity provides more flavors of the stats:
+The main activity considers all sleeps for the selected duration when counting the sleeps or when
+calculating the 2 kind of averages for your sleeps. The stats activity provides more flavors of the
+stats:
 
 - last week
 
-- from the beginning of the current year
+- last two weeks
+
+- last month
+
+- last year
 
 - all time (same as the main activity)
 


### PR DESCRIPTION
Adds a new setting to customize the dashboard duration, which filters
the sleeps visible on the dashboard to the selected duration as well as
the statistics.

Fixes <#88>.