### PR TITLE
CI: require passing ktlint

### DIFF
--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -13,6 +13,10 @@
 ./gradlew test
 ./gradlew connectedAndroidTest
 
+curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.40.0/ktlint
+chmod a+x ktlint
+git ls-files| grep '\.kt[s"]\?$' | xargs ./ktlint --android --relative .
+
 mkdir dist
 cp app/build/outputs/apk/release/app-release-unsigned.apk dist/
 


### PR DESCRIPTION
In case git-hooks/pre-commit was not enabled locally.

Change-Id: I7f7674aecdc6d53bbfc0343322b46c8f344e05d5
