### PR TITLE
Add a simple quick settings tile

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Resolves: gh#94 Add quick settings tile to start/stop tracking
+
 == 7.1.2
 
 - Awake-for and rating property of the sleep card is now hidden by default

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,16 @@
         </activity>
         <activity android:name=".PreferencesActivity" />
         <service android:name=".MainService"/>
+        <service
+            android:name=".TileService"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:label="@string/widget_start_stop"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action
+                    android:name="android.service.quicksettings.action.QS_TILE"/>
+            </intent-filter>
+        </service>
         <receiver
             android:icon="@mipmap/ic_launcher"
             android:label="@string/widget_start_stop"

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -61,7 +61,13 @@ object DataModel {
     val sleepsLive: LiveData<List<Sleep>>
         get() = database.sleepDao().getAllLive()
 
+    var initialized: Boolean = false
+
     fun init(context: Context, preferences: SharedPreferences) {
+        if (initialized) {
+            return
+        }
+
         this.preferences = preferences
 
         val start = preferences.getLong("start", 0)
@@ -73,6 +79,7 @@ object DataModel {
         database = Room.databaseBuilder(context, AppDatabase::class.java, "database")
             .addMigrations(MIGRATION_1_2)
             .build()
+        initialized = true
     }
 
     suspend fun storeSleep() {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/TileService.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/TileService.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Miklos Vajna. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package hu.vmiklos.plees_tracker
+
+import android.content.Intent
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.preference.PreferenceManager
+
+/**
+ * Provides a quick settings tile that opens the main activity and immediately toggles between
+ * started/stopped sleep tracking.
+ */
+@RequiresApi(api = Build.VERSION_CODES.N)
+class TileService : android.service.quicksettings.TileService() {
+
+    override fun onStartListening() {
+        refreshTile()
+    }
+
+    override fun onTileAdded() {
+        refreshTile()
+    }
+
+    private fun refreshTile() {
+        val preferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+        DataModel.init(applicationContext, preferences)
+
+        val active = DataModel.start != null && DataModel.stop == null
+
+        if (active) {
+            qsTile.state = Tile.STATE_ACTIVE
+        } else {
+            qsTile.state = Tile.STATE_INACTIVE
+        }
+        qsTile.updateTile()
+    }
+
+    override fun onClick() {
+        try {
+            if (qsTile.state == Tile.STATE_ACTIVE) {
+                qsTile.state = Tile.STATE_INACTIVE
+            } else {
+                qsTile.state = Tile.STATE_ACTIVE
+            }
+            qsTile.updateTile()
+
+            val intent = Intent(applicationContext, MainActivity::class.java)
+            intent.putExtra("startStop", true)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivityAndCollapse(intent)
+        } catch (e: Exception) {
+            Log.e(TAG, "onClick: uncaught exception: $e")
+        }
+    }
+
+    companion object {
+        private const val TAG = "TileService"
+    }
+}

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -40,6 +40,11 @@ The menu of this activity allows:
 A widget can be added to your home screen. This allows starting or stopping the tracking with a
 single tap: i.e. it's the same as opening the app and tapping on the start/stop button.
 
+== Quick settings tile
+
+A quick settings tile can be added to your panel. This allows starting or stopping the tracking with
+a single tap: i.e. it's the same as opening the app and tapping on the start/stop button.
+
 == Preferences activity
 
 This allows manually setting the dark mode for plees-tracker. This is useful on Android versions <=


### PR DESCRIPTION
I'm not exactly sure how to do DB operations without view models, so
just do it the same way as the widget: open the activity with a relevant
flag and then let it do its work.

Fixes <https://github.com/vmiklos/plees-tracker/issues/94>.

Change-Id: If1fe55aee5c2e77f2e4aa4b5845c755365e19176
