### PR TITLE
main activity: make the rating widget read-only

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Resolves: gh#161 main activity: make the rating widget read-only
+
 == 7.1.5
 
 - Resolves: gh#157 hint that swiping the sleep will delete it

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -16,7 +16,6 @@ import android.os.Bundle
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
-import android.view.MotionEvent
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -88,40 +87,6 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-    /**
-     * Determines if x,y hits view or not.
-     */
-    private fun hitTest(view: View, x: Float, y: Float): Boolean {
-        val translationX = view.translationX
-        val translationY = view.translationY
-        if (x < view.left + translationX) {
-            return false
-        }
-        if (x > view.right + translationX) {
-            return false
-        }
-        if (y < view.top + translationY) {
-            return false
-        }
-        if (y > view.bottom + translationY) {
-            return false
-        }
-
-        return true
-    }
-
-    /**
-     * If there is a rating bar inside this recycler view, get that.
-     */
-    private fun findRatingBar(rv: RecyclerView, e: MotionEvent): View? {
-        val sleepItem = rv.findChildViewUnder(e.x, e.y) ?: return null
-        val ratingBar = sleepItem.findViewById<View>(R.id.sleep_item_rating)
-        if (hitTest(ratingBar, e.x, e.y)) {
-            return ratingBar
-        }
-        return null
-    }
-
     private fun setDashboardText(durationStr: String) {
         var index = resources.getStringArray(R.array.duration_entry_values).indexOf(durationStr)
         val durations = resources.getStringArray(R.array.duration_entries)
@@ -183,25 +148,6 @@ class MainActivity : AppCompatActivity() {
                     recyclerView.scrollToPosition(positionStart)
                 }
             })
-
-        // Swipe on the rating bar goes to the rating bar itself.
-        if (preferences.getBoolean("show_rating", false)) {
-            recyclerView.addOnItemTouchListener(
-                object : RecyclerView.SimpleOnItemTouchListener() {
-                    override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
-                        return findRatingBar(rv, e) != null
-                    }
-
-                    override fun onTouchEvent(rv: RecyclerView, e: MotionEvent) {
-                        val ratingBar = findRatingBar(rv, e) ?: return
-                        val x = e.x - (ratingBar.left + ratingBar.translationX)
-                        val y = e.y - (ratingBar.top + ratingBar.translationY)
-                        e.setLocation(x, y)
-                        ratingBar.onTouchEvent(e)
-                    }
-                }
-            )
-        }
 
         // Otherwise swipe on a card view deletes it.
         val itemTouchHelper = ItemTouchHelper(

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepRateCallback.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepRateCallback.kt
@@ -12,7 +12,8 @@ import android.widget.RatingBar
  * This callback handles the rating of an individual sleep.
  */
 class SleepRateCallback(
-    private val viewModel: MainViewModel,
+    private val activity: SleepActivity,
+    private val viewModel: SleepViewModel,
     private val sleep: Sleep
 ) : RatingBar.OnRatingBarChangeListener {
     override fun onRatingChanged(ratingBar: RatingBar?, rating: Float, fromUser: Boolean) {
@@ -20,6 +21,6 @@ class SleepRateCallback(
             return
         }
         sleep.rating = rating.toLong()
-        viewModel.updateSleep(sleep)
+        viewModel.updateSleep(activity, sleep)
     }
 }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
@@ -11,6 +11,7 @@ import android.app.TimePickerDialog
 import android.content.ContentResolver
 import android.content.Context
 import android.text.format.DateFormat
+import android.widget.RatingBar
 import android.widget.TextView
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -21,9 +22,10 @@ import kotlinx.coroutines.launch
 /**
  * This is the view model of SleepActivity, providing coroutine scopes.
  */
-class SleepViewModel : ViewModel() {
+class SleepViewModel() : ViewModel() {
 
     fun showSleep(activity: SleepActivity, sid: Int) {
+        val viewModel = this
         viewModelScope.launch {
             val sleep = DataModel.getSleepById(sid)
 
@@ -31,6 +33,9 @@ class SleepViewModel : ViewModel() {
             start.text = DataModel.formatTimestamp(Date(sleep.start))
             val stop = activity.findViewById<TextView>(R.id.sleep_stop)
             stop.text = DataModel.formatTimestamp(Date(sleep.stop))
+            val rating = activity.findViewById<RatingBar>(R.id.sleep_item_rating)
+            rating.rating = sleep.rating.toFloat()
+            rating.onRatingBarChangeListener = SleepRateCallback(activity, viewModel, sleep)
         }
     }
 
@@ -85,6 +90,13 @@ class SleepViewModel : ViewModel() {
         viewModelScope.launch {
             DataModel.updateSleep(sleep)
             DataModel.backupSleeps(context, cr)
+            showSleep(activity, sleep.sid)
+        }
+    }
+
+    fun updateSleep(activity: SleepActivity, sleep: Sleep) {
+        viewModelScope.launch {
+            DataModel.updateSleep(sleep)
             showSleep(activity, sleep.sid)
         }
     }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepsAdapter.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepsAdapter.kt
@@ -105,7 +105,6 @@ class SleepsAdapter(
 
         if (preferences.getBoolean("show_rating", false)) {
             holder.rating.rating = sleep.rating.toFloat()
-            holder.rating.onRatingBarChangeListener = SleepRateCallback(viewModel, sleep)
         } else {
             holder.rating.visibility = View.GONE
         }

--- a/app/src/main/res/layout/activity_sleep.xml
+++ b/app/src/main/res/layout/activity_sleep.xml
@@ -24,7 +24,7 @@
 
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="120dp"
+        android:layout_height="wrap_content"
         android:layout_below="@id/sleep_details_header"
         android:layout_marginTop="10dp"
         app:cardCornerRadius="4dp"
@@ -41,10 +41,10 @@
 
             <ImageView
                 android:id="@+id/start_image"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
-                android:layout_marginTop="5dp"
+                android:layout_marginTop="10dp"
                 android:src="@drawable/ic_play_green"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
@@ -55,35 +55,11 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
-                android:layout_marginTop="5dp"
+                android:layout_marginTop="10dp"
                 android:text="@string/started_on"
                 android:textSize="16sp"
-                app:layout_constraintStart_toEndOf="@id/stop_red_image"
-                app:layout_constraintTop_toTopOf="parent" />
-
-
-            <ImageView
-                android:id="@+id/stop_red_image"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginStart="10dp"
-                android:layout_marginTop="10dp"
-                android:src="@drawable/ic_stop_red"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:contentDescription="@string/stopped_on" />
-
-            <TextView
-                android:id="@+id/stopped_on_header"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="10dp"
-                android:layout_marginTop="10dp"
-                android:text="@string/stopped_on"
-                android:textSize="16sp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/stop_red_image"
+                app:layout_constraintBottom_toBottomOf="@+id/start_image"
+                app:layout_constraintStart_toEndOf="@+id/start_image"
                 app:layout_constraintTop_toTopOf="parent" />
 
 
@@ -95,9 +71,33 @@
                 android:layout_marginEnd="20dp"
                 android:onClick="editDateTime"
                 android:textSize="16sp"
+                app:layout_constraintBottom_toBottomOf="@+id/start_image"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 tools:text="10:50:38" />
+
+
+            <ImageView
+                android:id="@+id/stop_red_image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:src="@drawable/ic_stop_red"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/start_image"/>
+
+            <TextView
+                android:id="@+id/stopped_on_header"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:text="@string/stopped_on"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toBottomOf="@+id/stop_red_image"
+                app:layout_constraintStart_toEndOf="@+id/stop_red_image"
+                app:layout_constraintTop_toTopOf="@+id/stop_red_image" />
 
 
             <TextView
@@ -108,10 +108,24 @@
                 android:layout_marginEnd="20dp"
                 android:onClick="editDateTime"
                 android:textSize="16sp"
-                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintBottom_toBottomOf="@+id/stop_red_image"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/stop_red_image"
                 tools:text="10:50:38" />
+
+            <RatingBar
+                android:id="@+id/sleep_item_rating"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="10dp"
+                android:numStars="5"
+                android:rating="0"
+                android:stepSize="1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/stop_red_image" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/layout_sleep_item.xml
+++ b/app/src/main/res/layout/layout_sleep_item.xml
@@ -187,7 +187,8 @@
                 android:stepSize="1"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/wake_time_image" />
+                app:layout_constraintTop_toBottomOf="@id/wake_time_image"
+                android:isIndicator="true"/>
 
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -65,15 +65,16 @@ The past sleeps section allow configuring the contents of the individual sleep c
 
 - awake time is hidden by default
 
-- rating is hidden by default
+- the read-only rating is hidden by default on the main activity, the read-write rating is always
+  visible in the sleep activity
 
 The sleep cards are not re-created when changing settings, so you need to restart plees-tracker to
 see the effect.
 
 == Sleep activity
 
-The sleep activity allows modifying the start or stop time of a single recorded sleep, which is
-useful if you want to update the recorded timestamps to better match reality.
+The sleep activity allows modifying the start,  stop time or rating of a single recorded sleep,
+which is useful if you want to update the recorded timestamps to better match reality.
 
 == Stats activity
 


### PR DESCRIPTION
It's better to leave the editing functionality to the dedicated sleep
activity.

Fixes <https://github.com/vmiklos/plees-tracker/issues/161>.

Change-Id: Id96ae6d1ec7d9b1dd512899bcbaa5fb246a093e5
