### PR TITLE
CI: update android-emulator-runner to v2.19.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
     - name: run tests
-      uses: reactivecircus/android-emulator-runner@v2
+      uses: reactivecircus/android-emulator-runner@v2.19.0
       with:
         api-level: 27
         script: tools/ci-build.sh


### PR DESCRIPTION
To see if this helps with the hang that doesn't happen for me locally.

Change-Id: I7048f01f7c1d756aefb4686b7ecff4c0ee21457a
