### PR TITLE
sleep activity: prevent negative sleep durations

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Resolves: gh#178 prevent negative sleep durations
+
 == 7.2.1
 
 - Resolves: gh#184 fixed overlapped and blocked texts on main page (yuhuitech)

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
@@ -13,6 +13,7 @@ import android.content.Context
 import android.text.format.DateFormat
 import android.widget.RatingBar
 import android.widget.TextView
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import java.util.Calendar
@@ -70,7 +71,14 @@ class SleepViewModel : ViewModel() {
                             } else {
                                 sleep.stop = dateTime.time.time
                             }
-                            updateSleep(activity, sleep, context, cr)
+                            if (sleep.start < sleep.stop) {
+                                updateSleep(activity, sleep, context, cr)
+                            } else {
+                                val text = context.getString(R.string.negative_duration)
+                                val duration = Toast.LENGTH_SHORT
+                                val toast = Toast.makeText(context, text, duration)
+                                toast.show()
+                            }
                         },
                         dateTime[Calendar.HOUR_OF_DAY], dateTime[Calendar.MINUTE],
                         /*is24HourView=*/DateFormat.is24HourFormat(activity)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,4 +165,5 @@
         <item>"13.5"</item>
         <item>"14.0"</item>
     </string-array>
+    <string name="negative_duration">Not updating the sleep, stop is not after start.</string>
 </resources>


### PR DESCRIPTION
It's hard to guess what is the intent when the duration would be
negative (either the new start/stop date is incorrectly provided or you
meant to adjust the other end first), so just refusing the edit with a
clear error is the best.

Fixes <https://github.com/vmiklos/plees-tracker/issues/178>.

Change-Id: I79597b06e2d9e8a14366578771a6bc2850b03125
