### PR TITLE
Calendar import: read sleeps incrementally

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,8 +1,12 @@
 = Version descriptions
 
+== master
+
+- Resolves: gh#207 avoid duplicate entries when importing from calendar multiple times
+
 == 7.2.3
 
-- Resolves: gh#150 avoid duplicate entries when exportinging to calendar multiple times
+- Resolves: gh#150 avoid duplicate entries when exporting to calendar multiple times
 
 == 7.2.2
 

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -28,6 +28,8 @@ This activity allows:
 The menu of this activity allows:
 
 - Import/export your sleeps to CSV. The start and stop columns are UNIX timestamps in milliseconds.
+  The import is incremental, i.e. it remembers what items are imported and the next time only newer
+  items will be imported.
 
 - Import/export your sleeps to calendar. The export is incremental, i.e. it remembers what items are
   exported, and the next time only newer items will be exported.


### PR DESCRIPTION
To avoid duplicates when importing more than once.

Fixes <https://github.com/vmiklos/plees-tracker/issues/207>.

Change-Id: I28da934c4171e9e57cf00c39c67715829c1f1bfe
