### PR TITLE
main activity: enable separators between sleep items

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Resolves: gh#208 add separators between sleep items in the main activity
+
 == 7.2.4
 
 - Resolves: gh#207 avoid duplicate entries when importing from calendar multiple times

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -28,6 +28,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -138,10 +139,19 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         )
 
         val recyclerView = findViewById<RecyclerView>(R.id.sleeps)
-        recyclerView.layoutManager = LinearLayoutManager(this)
+        val recyclerViewLayout = LinearLayoutManager(this)
+        recyclerView.layoutManager = recyclerViewLayout
         recyclerView.setHasFixedSize(true)
         recyclerView.itemAnimator = DefaultItemAnimator()
         recyclerView.adapter = sleepsAdapter
+
+        // Enable separators between sleep items.
+        val dividerItemDecoration = DividerItemDecoration(
+            recyclerView.context,
+            recyclerViewLayout.orientation
+        )
+        recyclerView.addItemDecoration(dividerItemDecoration)
+
         sleepsAdapter.registerAdapterDataObserver(
             object : RecyclerView.AdapterDataObserver() {
                 override fun onItemRangeInserted(


### PR DESCRIPTION
An alternative solution would be to migrate to MaterialCardView which
has a stroke width/color property, but that seems to break e.g. tapping
on the start/stop FAB, so go with an explicit divider.

Fixes <https://github.com/vmiklos/plees-tracker/issues/208>.

Change-Id: Ibb79568ef8b8e74b1ea3ddd9f280e96037fd4263
