### PR TITLE
Fix for duplicates on calendar import/export and file import

### DIFF
--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityInstrumentedTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityInstrumentedTest.kt
@@ -24,6 +24,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import java.io.File
+import java.time.Duration
+import java.util.Calendar
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -32,9 +35,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
-import java.io.File
-import java.time.Duration
-import java.util.Calendar
 
 /**
  * Instrumented tests for MainActivity.

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityInstrumentedTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityInstrumentedTest.kt
@@ -24,8 +24,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
-import java.io.File
-import java.util.Calendar
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -34,7 +32,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
+import java.io.File
 import java.time.Duration
+import java.util.Calendar
 
 /**
  * Instrumented tests for MainActivity.

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -255,7 +255,7 @@ object DataModel {
             os.write("sid,start,stop,rating\n".toByteArray())
             for (sleep in sleeps) {
                 val row = sleep.sid.toString() + "," + sleep.start.toString() + "," +
-                        sleep.stop.toString() + "," + sleep.rating.toString() + "\n"
+                    sleep.stop.toString() + "," + sleep.rating.toString() + "\n"
                 os.write(row.toByteArray())
             }
         } catch (e: IOException) {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -130,7 +130,7 @@ object DataModel {
         // memory: the benefit is that inserting all of them once triggers a single notification of
         // observers. This means that importing 100s of sleeps is still ~instant, while it used to
         // take ~forever.
-        val sleeps = mutableListOf<Sleep>()
+        val importedSleeps = mutableListOf<Sleep>()
         try {
             var first = true
             while (true) {
@@ -150,9 +150,11 @@ object DataModel {
                 if (cells.size >= 4) {
                     sleep.rating = cells[3].toLong()
                 }
-                sleeps.add(sleep)
+                importedSleeps.add(sleep)
             }
-            database.sleepDao().insert(sleeps)
+            val oldSleeps = database.sleepDao().getAll()
+            val newSleeps = importedSleeps.subtract(oldSleeps)
+            database.sleepDao().insert(newSleeps.toList())
         } catch (e: IOException) {
             Log.e(TAG, "importData: readLine() failed")
             return
@@ -238,7 +240,7 @@ object DataModel {
             os.write("sid,start,stop,rating\n".toByteArray())
             for (sleep in sleeps) {
                 val row = sleep.sid.toString() + "," + sleep.start.toString() + "," +
-                    sleep.stop.toString() + "," + sleep.rating.toString() + "\n"
+                        sleep.stop.toString() + "," + sleep.rating.toString() + "\n"
                 os.write(row.toByteArray())
             }
         } catch (e: IOException) {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -193,20 +193,16 @@ object DataModel {
     }
 
     suspend fun exportDataToCalendar(context: Context, calendarId: String) {
-        // Get all sleeps after the last export, or all of them if there was no previous export.
-        val now = Calendar.getInstance().time
-        var lastCalendarExport = preferences.getLong("last_calendar_export", 0)
-        val sleeps = database.sleepDao().getAfter(lastCalendarExport)
+        val calendarSleeps = CalendarImport.queryForEvents(
+            context, calendarId
+        ).map(CalendarImport::mapEventToSleep)
+        val sleeps = database.sleepDao().getAll()
+        val exportedSleeps = sleeps.subtract(calendarSleeps)
 
-        CalendarExport.exportSleep(context, calendarId, sleeps)
-
-        // Remember the current time for the last export.
-        val editor = preferences.edit()
-        editor.putLong("last_calendar_export", now.time)
-        editor.apply()
+        CalendarExport.exportSleep(context, calendarId, exportedSleeps.toList())
 
         // Show how many sleeps were exported.
-        val text = String.format(context.getString(R.string.exported_items), sleeps.size)
+        val text = String.format(context.getString(R.string.exported_items), exportedSleeps.size)
         val duration = Toast.LENGTH_SHORT
         val toast = Toast.makeText(context, text, duration)
         toast.show()

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -407,28 +407,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
     }
 
     private fun importCalendarData(selectedItem: UserCalendar) {
-        // Get all sleeps after the last import, or all of them if there was no previous import.
-        val now = Calendar.getInstance().time
-        var lastCalendarImport = DataModel.preferences.getLong("last_calendar_import", 0)
-
-        // Query the calendar for events
-        var sleepList = CalendarImport.queryForEvents(
-            this, selectedItem.id
-        ).map(CalendarImport::mapEventToSleep)
-        sleepList = sleepList.filter { it.stop > lastCalendarImport }
-
-        // Insert the list of Sleep into DB
-        viewModel.insertSleeps(sleepList)
-
-        // Remember the current time for the last import.
-        val editor = DataModel.preferences.edit()
-        editor.putLong("last_calendar_import", now.time)
-        editor.apply()
-
-        // Show how many sleeps were imported.
-        Toast.makeText(
-            this, getString(R.string.imported_items, sleepList.size), Toast.LENGTH_SHORT
-        ).show()
+        viewModel.importDataFromCalendar(this, selectedItem.id)
     }
 
     private fun exportCalendarData(selectedItem: UserCalendar) {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainViewModel.kt
@@ -15,9 +15,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.viewModelScope
 import androidx.preference.PreferenceManager
-import kotlinx.coroutines.launch
 import java.util.Calendar
 import java.util.Date
+import kotlinx.coroutines.launch
 
 /**
  * This is the view model of MainActivity, providing coroutine scopes.

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainViewModel.kt
@@ -53,6 +53,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun importDataFromCalendar(context: Context, calendarId: String) {
+        viewModelScope.launch {
+            DataModel.importDataFromCalendar(context, calendarId)
+        }
+    }
+
     fun exportDataToCalendar(context: Context, calendarId: String) {
         viewModelScope.launch {
             DataModel.exportDataToCalendar(context, calendarId)

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainViewModel.kt
@@ -15,9 +15,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.viewModelScope
 import androidx.preference.PreferenceManager
+import kotlinx.coroutines.launch
 import java.util.Calendar
 import java.util.Date
-import kotlinx.coroutines.launch
 
 /**
  * This is the view model of MainActivity, providing coroutine scopes.
@@ -27,8 +27,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val preferences = PreferenceManager.getDefaultSharedPreferences(application)
 
     val durationSleepsLive: LiveData<List<Sleep>> =
-        Transformations.switchMap(preferences.liveData("dashboard_duration", "0")) {
-            durationStr ->
+        Transformations.switchMap(preferences.liveData("dashboard_duration", "0")) { durationStr ->
             val duration = durationStr?.toInt() ?: 0
             val date = if (duration == 0) {
                 Date(0)

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Sleep.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Sleep.kt
@@ -33,6 +33,17 @@ class Sleep {
 
     val lengthHours
         get() = lengthMs.toFloat() / DateUtils.HOUR_IN_MILLIS
+
+    override fun equals(other: Any?): Boolean =
+        other is Sleep &&
+                other.start == start &&
+                other.stop == stop
+
+    override fun hashCode(): Int {
+        var result = start.hashCode()
+        result = 31 * result + stop.hashCode()
+        return result
+    }
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Sleep.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Sleep.kt
@@ -36,8 +36,8 @@ class Sleep {
 
     override fun equals(other: Any?): Boolean =
         other is Sleep &&
-                other.start == start &&
-                other.stop == stop
+            other.start == start &&
+            other.stop == stop
 
     override fun hashCode(): Int {
         var result = start.hashCode()

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepDao.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepDao.kt
@@ -20,8 +20,10 @@ import androidx.room.Update
 interface SleepDao {
     @Query("SELECT * FROM sleep ORDER BY sid ASC")
     suspend fun getAll(): List<Sleep>
+
     @Query("SELECT * FROM sleep ORDER BY start_date DESC")
     fun getAllLive(): LiveData<List<Sleep>>
+
     @Query("SELECT * from sleep where sid = :id LIMIT 1")
     suspend fun getById(id: Int): Sleep
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
@@ -16,9 +16,9 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.launch
 import java.util.Calendar
 import java.util.Date
+import kotlinx.coroutines.launch
 
 /**
  * This is the view model of SleepActivity, providing coroutine scopes.

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
@@ -16,9 +16,9 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
 import java.util.Calendar
 import java.util.Date
-import kotlinx.coroutines.launch
 
 /**
  * This is the view model of SleepActivity, providing coroutine scopes.


### PR DESCRIPTION
Instead of using a timestamp to make sure no duplicates, I figured it's more robust to just goes through the sleeps and and make sure no duplicates are added based on the start and stop times. It's not the most efficient way, but the data types used are very small and importing/exporting is not done that frequently so it shouldn't really matter.

This fixes calendar importing/exporting duplicates, and also duplicates from importing .csv files.

Also moves calendar importing logic from MainActivity to DataModel since that's where exporting logic is, and seems to fit better.

Related to #150 #207 #209