### PR TITLE
CI: build on macos-11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
       - 'private/**'
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - name: checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
> macOS-latest workflows will use macOS-11 soon. For more details, see https://github.com/actions/virtual-environments/issues/4060

So try to do that upgrade early to see if it works.

Change-Id: I3f0d0274cfd673037226f684d9f7a975ca10cc65
