### PR TITLE
Sleep comments: add UI

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -2,6 +2,7 @@
 
 == master
 
+- Resolves: gh#239 it is now possible to comment sleeps
 - No longer using `android:onClick`, which is broken on older versions of Android
 
 == 7.2.5

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepCommentCallback.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepCommentCallback.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Miklos Vajna. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package hu.vmiklos.plees_tracker
+
+import android.text.Editable
+import android.text.TextWatcher
+
+/**
+ * This callback handles the comment of an individual sleep.
+ */
+class SleepCommentCallback(
+    private val activity: SleepActivity,
+    private val viewModel: SleepViewModel,
+    private val sleep: Sleep
+) : TextWatcher {
+    override fun afterTextChanged(s: Editable?) {
+    }
+
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+    }
+
+    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+        sleep.comment = s.toString()
+        viewModel.updateSleep(activity, sleep, true)
+    }
+}

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepRateCallback.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepRateCallback.kt
@@ -21,6 +21,6 @@ class SleepRateCallback(
             return
         }
         sleep.rating = rating.toLong()
-        viewModel.updateSleep(activity, sleep)
+        viewModel.updateSleep(activity, sleep, false)
     }
 }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
@@ -14,6 +14,7 @@ import android.text.format.DateFormat
 import android.widget.RatingBar
 import android.widget.TextView
 import android.widget.Toast
+import androidx.appcompat.widget.AppCompatEditText
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import java.util.Calendar
@@ -37,6 +38,9 @@ class SleepViewModel : ViewModel() {
             val rating = activity.findViewById<RatingBar>(R.id.sleep_item_rating)
             rating.rating = sleep.rating.toFloat()
             rating.onRatingBarChangeListener = SleepRateCallback(activity, viewModel, sleep)
+            val comment = activity.findViewById<AppCompatEditText>(R.id.sleep_item_comment)
+            comment.setText(sleep.comment)
+            comment.addTextChangedListener(SleepCommentCallback(activity, viewModel, sleep))
         }
     }
 
@@ -102,10 +106,13 @@ class SleepViewModel : ViewModel() {
         }
     }
 
-    fun updateSleep(activity: SleepActivity, sleep: Sleep) {
+    fun updateSleep(activity: SleepActivity, sleep: Sleep, fromUI: Boolean) {
         viewModelScope.launch {
             DataModel.updateSleep(sleep)
-            showSleep(activity, sleep.sid)
+            if (!fromUI) {
+                // TODO we should probably never do this
+                showSleep(activity, sleep.sid)
+            }
         }
     }
 }

--- a/app/src/main/res/layout/activity_sleep.xml
+++ b/app/src/main/res/layout/activity_sleep.xml
@@ -125,6 +125,15 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/stop_red_image" />
 
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/sleep_item_comment"
+                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                android:inputType="textAutoCorrect"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/sleep_item_rating" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.cardview.widget.CardView>
 


### PR DESCRIPTION
This requires improving SleepViewModel.updateSleep(), so that there is
no loop between SleepCommentCallback.onTextChanged() and
SleepViewModel.updateSleep().

This was not a problem with the rating and is good enough for now, but
needs revisiting later.

Resolves <https://github.com/vmiklos/plees-tracker/issues/239>.

Change-Id: Ie375ecec35e317b3b5b9d1c7ebd180be87983059
