### PR TITLE
sleep activity: allow multi-line notes

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Resolves: gh#277 sleep activity: allow multi-line notes
+
 == 7.3.2
 
 - Show timezone at sleep start/stop timestamps

--- a/app/src/main/res/layout/activity_sleep.xml
+++ b/app/src/main/res/layout/activity_sleep.xml
@@ -142,7 +142,7 @@
                 android:layout_width="0dp"
                 android:layout_marginStart="10dp"
                 android:layout_marginEnd="10dp"
-                android:inputType="textAutoCorrect"
+                android:inputType="textMultiLine"
                 app:layout_constraintStart_toEndOf="@id/sleep_item_comment_label"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/sleep_item_rating" />


### PR DESCRIPTION
The CSV import/export was already capable of doing this.

Fixes <https://github.com/vmiklos/plees-tracker/issues/277>.

Change-Id: I5157792558d06904498ae57b566596fe63c0f160
