### PR TITLE
CI: optionally sign release APKs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,11 @@ jobs:
       with:
         api-level: 27
         script: tools/ci-build.sh
+      env:
+        KEYSTORE: ${{ secrets.KEYSTORE }}
+        SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+        SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+        SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
     - uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,10 +18,21 @@ android {
             }
         }
     }
+    signingConfigs {
+        release {
+            storeFile = file("keystore/plees_keystore.jks")
+            storePassword System.getenv("SIGNING_STORE_PASSWORD")
+            keyAlias System.getenv("SIGNING_KEY_ALIAS")
+            keyPassword System.getenv("SIGNING_KEY_PASSWORD")
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            if (file("keystore/plees_keystore.jks").exists()) {
+                signingConfig signingConfigs.release
+            }
         }
     }
     buildFeatures {

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -9,6 +9,9 @@
 # This script runs all the tests for CI purposes.
 #
 
+mkdir -p app/keystore/
+echo $KEYSTORE | base64 -d > app/keystore/plees_keystore.jks
+
 ./gradlew build
 ./gradlew test
 ./gradlew connectedAndroidTest
@@ -20,6 +23,6 @@ git ls-files| grep '\.kt[s"]\?$' | xargs ./ktlint --android --relative .
 tools/license-check.sh
 
 mkdir dist
-cp app/build/outputs/apk/release/app-release-unsigned.apk dist/
+cp app/build/outputs/apk/release/app-release.apk dist/
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
If a app/keystore/plees_keystore.jks exists, then sign the release APK
using that. If it's not there, then the behavior is meant to be
unchanged.

Finally do provide such a keystore during the CI build.

Related to <https://github.com/vmiklos/plees-tracker/issues/298>.

Change-Id: I70a08fa74960b15529dc0f7258973a4031415d99
