### PR TITLE
data model: add a start time offset

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -2,6 +2,7 @@
 
 == master
 
+- Resolves: gh#274 add a start time offset
 - Resolves: gh#298 release builds are now signed even outside F-Droid
 
 == 7.3.5

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -94,6 +94,11 @@ object DataModel {
         initialized = true
     }
 
+    private fun getStartDelay(): Int {
+        val startDelayStr = preferences.getString("sleep_start_delta", "0") ?: "0"
+        return startDelayStr.toIntOrNull() ?: 0
+    }
+
     suspend fun storeSleep() {
         val sleep = Sleep()
         start?.let {
@@ -102,6 +107,14 @@ object DataModel {
         stop?.let {
             sleep.stop = it.time
         }
+
+        val startDelayMS = getStartDelay() * 60 * 1000
+        if (sleep.start + startDelayMS > sleep.stop) {
+            sleep.start = sleep.stop
+        } else {
+            sleep.start += startDelayMS
+        }
+
         database.sleepDao().insert(sleep)
 
         // Drop start timestamp from preferences, it's in the database now.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,12 @@
     <string name="hours_13">"13 hours"</string>
     <string name="hours_13_30">"13 hours 30 minutes"</string>
     <string name="hours_14">"14 hours"</string>
+    <string name="settings_sleep_start_delta">Start time delay</string>
+    <string name="minutes_0">0 minutes</string>
+    <string name="minute_1">1 minute</string>
+    <string name="minutes_5">5 minutes</string>
+    <string name="minutes_10">10 minutes</string>
+    <string name="minutes_15">15 minutes</string>
     <string name="show_rating">Show rating</string>
     <string name="show_awake_duration">Show awake duration</string>
     <string name="past_sleeps">Past sleeps</string>
@@ -171,6 +177,20 @@
         <item>"13.0"</item>
         <item>"13.5"</item>
         <item>"14.0"</item>
+    </string-array>
+    <string-array name="sleep_start_delay_entries">
+        <item>@string/minutes_0</item>
+        <item>@string/minute_1</item>
+        <item>@string/minutes_5</item>
+        <item>@string/minutes_10</item>
+        <item>@string/minutes_15</item>
+    </string-array>
+    <string-array name="sleep_start_delay_entry_values">
+        <item>"0"</item>
+        <item>"1"</item>
+        <item>"5"</item>
+        <item>"10"</item>
+        <item>"15"</item>
     </string-array>
     <string name="negative_duration">Not updating the sleep, stop is not after start.</string>
     <string name="sleep_notes">Notes:</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -39,6 +39,13 @@
             android:entryValues="@array/ideal_sleep_entry_values"
             android:defaultValue="8.0"
             app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:key="sleep_start_delta"
+            android:title="@string/settings_sleep_start_delta"
+            android:entries="@array/sleep_start_delay_entries"
+            android:entryValues="@array/sleep_start_delay_entry_values"
+            android:defaultValue="0.0"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/past_sleeps">

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -64,6 +64,10 @@ the past week.
 There is also an option to define your ideal sleep length, which is used for some of the graphs (see
 Graphs activity below).
 
+The other setting influencing the sleep stats is a sleep start delay. Assuming that one presses
+start, followed by 8 hours, then stop, in case a sleep delay of 15 minutes is set, the recorded
+sleep length will be 7:45, not 8:00, by increasing the sleep start timestamp.
+
 The past sleeps section allow configuring the contents of the individual sleep cards:
 
 - awake time is hidden by default


### PR DESCRIPTION
Assuming one doesn't fall asleep right after the start, reduce duration
by this fixed amount to have more real stats.

Fixes <https://github.com/vmiklos/plees-tracker/issues/274>.

Change-Id: I5c41419ef6b74431f55d6e161357c850933801ca
