### PR TITLE
Lower baseline to API 23 (Android 6.0)

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Resolves: gh#282 lower baseline to API 23 (Android 6.0), covering about 97.4% of devices
+
 == 7.4.0
 
 - Resolves: gh#274 add a start time offset

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "30.0.3"
     defaultConfig {
         applicationId "hu.vmiklos.plees_tracker"
-        minSdkVersion 24
+        minSdkVersion 23
         targetSdkVersion 31
         versionCode 34
         versionName "7.4.0"

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -388,7 +388,12 @@ object DataModel {
     }
 
     fun formatTimestamp(date: Date): String {
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX", Locale.getDefault())
+        val sdf = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            // The pattern character 'X' requires API level 24
+            SimpleDateFormat("yyyy-MM-dd HH:mm:ss XXX", Locale.getDefault())
+        } else {
+            SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+        }
         return sdf.format(date)
     }
 


### PR DESCRIPTION
All you loose is that you don't get timezone in timestamps, which is
just a nice-to-have.

Fixes <https://github.com/vmiklos/plees-tracker/issues/282>.

Change-Id: Ic0ad551843dee916d64b22398ccec906b1ae26bc
