### PR TITLE
sleep item layout: add dedicated icon for the 'awake for' row

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Resolves: gh#275 sleep item layout: add dedicated icon for the 'awake for' row
+
 == 7.4.2
 
 - Resolves: gh#309 dashboard: hide seconds & timezone by default on the dashboard

--- a/app/src/main/res/drawable/ic_awake_for.xml
+++ b/app/src/main/res/drawable/ic_awake_for.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="#FFFF00"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M12.5,7H11v6l5.25,3.15 0.75,-1.23 -4.5,-2.67z"/>
+</vector>

--- a/app/src/main/res/layout/layout_sleep_item.xml
+++ b/app/src/main/res/layout/layout_sleep_item.xml
@@ -147,7 +147,7 @@
                 android:layout_marginStart="10dp"
                 android:layout_marginTop="10dp"
                 android:contentDescription="@string/awake_for_label"
-                android:src="@drawable/ic_play_green"
+                android:src="@drawable/ic_awake_for"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/sleep_time_image" />
 


### PR DESCRIPTION
Fixes <https://github.com/vmiklos/plees-tracker/issues/275>.

Change-Id: If744b6d76a768074144ac4fd6d3d37493938bc25
