### PR TITLE
Update targetSdkVersion to 33

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -3,6 +3,7 @@
 == master
 
 - Resolves: gh#275 sleep item layout: add dedicated icon for the 'awake for' row
+- Fixed the tracking notification to work with Android 13
 
 == 7.4.2
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     defaultConfig {
         applicationId "hu.vmiklos.plees_tracker"
         minSdkVersion 23
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 36
         versionName "7.4.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
 


### PR DESCRIPTION
I.e. fix the app to work with Android 13

See
<https://android.googlesource.com/platform/packages/apps/DeskClock/+/1baadbe248e0bcff32c9eb02483eb503e62eef94%5E%21/>,
the Clock app does the same now.

Change-Id: I921d286e82de52db1177ca45f67991f8942f52b7
