### PR TITLE
main activity: add placeholder text when there are no sleeps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Version descriptions
 
+## master
+
+- Resolves: gh#330 main activity: add placeholder text when there are no sleeps
+
 ## 7.4.3
 
 - Resolves: gh#275 sleep item layout: add dedicated icon for the 'awake for' row

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -120,6 +120,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         ) { setDashboardText(it ?: "0") }
 
         val sleepsAdapter = SleepsAdapter(preferences)
+        val recyclerView = findViewById<RecyclerView>(R.id.sleeps)
         viewModel.durationSleepsLive.observe(
             this
         ) { sleeps ->
@@ -139,10 +140,19 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
                     DataModel.getCompactView()
                 )
                 sleepsAdapter.data = sleeps
+
+                // Set up placeholder text if there are no sleeps.
+                val noSleepsView = findViewById<TextView>(R.id.no_sleeps)
+                if (sleeps.isEmpty()) {
+                    recyclerView.visibility = View.GONE
+                    noSleepsView.visibility = View.VISIBLE
+                } else {
+                    recyclerView.visibility = View.VISIBLE
+                    noSleepsView.visibility = View.GONE
+                }
             }
         }
 
-        val recyclerView = findViewById<RecyclerView>(R.id.sleeps)
         val recyclerViewLayout = LinearLayoutManager(this)
         recyclerView.layoutManager = recyclerViewLayout
         recyclerView.setHasFixedSize(true)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -108,6 +108,15 @@
             android:layout_margin="10dp"
             android:scrollbars="vertical"
             tools:listitem="@layout/layout_sleep_item" />
+        <TextView
+            android:id="@+id/no_sleeps"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="10dp"
+            android:text="@string/no_sleeps"
+            android:textColor="@color/textColor"
+            android:textSize="16sp"
+            android:visibility="gone" />
     </FrameLayout>
 
     <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,4 +198,5 @@
     <string name="delete_all_message">"Are you sure you want to delete all sleeps?"</string>
     <string name="delete_all_positive">Yes</string>
     <string name="delete_all_negative">No</string>
+    <string name="no_sleeps">Your tracked sleeps will appear here. Press Start to create a sleep, tap on a sleep to edit it and swipe away a sleep to delete it. For more info, see the Website menu item.</string>
 </resources>


### PR DESCRIPTION
The doc is hard to discover, so give a brief summary when no sleeps are
shown and point out the relevant menu item.

Resolves <https://github.com/vmiklos/plees-tracker/issues/330>.

Change-Id: I33ff6eea6490762a3345b06568de8c4d9027aa78
