### PR TITLE
DataModel: fix unused variable in empty catch block

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -192,7 +192,7 @@ object DataModel {
             if (inputStream != null) {
                 try {
                     inputStream.close()
-                } catch (e: Exception) {
+                } catch (_: Exception) {
                 }
             }
         }
@@ -301,7 +301,7 @@ object DataModel {
         } finally {
             try {
                 os.close()
-            } catch (e: Exception) {
+            } catch (_: Exception) {
             }
         }
 


### PR DESCRIPTION
These are closing resources, they are meant to be really empty.

Change-Id: I2b834ec319525da210a58609b41fc255f448d1cd
