### PR TITLE
Fix lack of toggle from the notification drawer when app is already foreground

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -99,6 +99,19 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
             getString(R.string.dashboard, durationHeaderStr)
     }
 
+    fun handleIntent(intent: Intent?) {
+        intent?.let {
+            if (it.getBooleanExtra("startStop", false)) {
+                onClick(findViewById(R.id.start_stop_layout))
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        handleIntent(intent)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -201,11 +214,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         recyclerView.setOnScrollChangeListener(listener)
 
         // See if the activity is triggered from the widget. If so, toggle the start/stop state.
-        intent?.let {
-            if (it.getBooleanExtra("startStop", false)) {
-                onClick(findViewById(R.id.start_stop_layout))
-            }
-        }
+        handleIntent(intent)
 
         updateView()
     }

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+- Resolves: gh#292 fix lack of toggle from the notification drawer when app is already foreground
+
 ## 7.4.4
 
 - Resolves: gh#330 main activity: add placeholder text when there are no sleeps


### PR DESCRIPTION
The steps from
<https://github.com/vmiklos/plees-tracker/issues/292#issuecomment-1185306926>
describe that in case the app is already in the foreground, then stop
from the notification drawer won't do anything.

The trouble is that the toggle is implemented as a side-effect of
the creation of the main activity, which is optimized away when the main
activity is already the top of the activity stack. The benefit of this
approach is that once the toggle happens from the main activity, we can
be sure that the DataModel singleton is initialized and also can use the
view model of the activity for coroutine purposes (the stop involves an
async db operation).

Fix the problem by following the advice from
<https://stackoverflow.com/questions/53459111/launch-activity-from-notification-instantiating-activity-even-if-already-there>:

- set the activity's launch mode to singleTop

- implement the new onNewIntent(), which will be called in the case
  where nothing happened previously

Note that toggle from the widget didn't have this problem, since you can
only see the widget when the activity is not at the top of the activity
stack.

Fixes <https://github.com/vmiklos/plees-tracker/issues/292>.

Change-Id: I6861673c0ada5c74d80654bebbc78f98fbb3aa8f
