### PR TITLE
Fix toggle widget to work on Android 12

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/ToggleWidget.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/ToggleWidget.kt
@@ -11,6 +11,7 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import android.widget.RemoteViews
 
 /**
@@ -23,6 +24,7 @@ class ToggleWidget : AppWidgetProvider() {
         appWidgetManager: AppWidgetManager?,
         appWidgetIds: IntArray?
     ) {
+        Log.d(TAG, "ToggleWidget.onUpdate")
         if (context == null) {
             return
         }
@@ -38,13 +40,21 @@ class ToggleWidget : AppWidgetProvider() {
         for (appWidgetId in appWidgetIds) {
             val intent = Intent(context, MainActivity::class.java)
             intent.putExtra("startStop", true)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            var flags = PendingIntent.FLAG_UPDATE_CURRENT
+            // Needed for Android 12+
+            flags = flags or PendingIntent.FLAG_IMMUTABLE
             val pendingIntent = PendingIntent.getActivity(
-                context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT
+                context, 0, intent, flags
             )
             val remoteViews = RemoteViews(context.packageName, R.layout.widget_layout_toggle)
             remoteViews.setOnClickPendingIntent(R.id.widget_toggle, pendingIntent)
             appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
         }
+    }
+
+    companion object {
+        private const val TAG = "ToggleWidget"
     }
 }
 

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+- Resolves: gh#359 fix the widget to start/stop tracking to work on Android 12+
+
 ## 7.5.0
 
 - Resolves: gh#308 main activity: default to showing average of daily sums only


### PR DESCRIPTION
- Intent.FLAG_ACTIVITY_NEW_TASK was used in the working TileService, but
  not in the widget

- PendingIntent.FLAG_IMMUTABLE was used in the working MainService, but
  not in the widget

Fixes <https://github.com/vmiklos/plees-tracker/issues/359>.

Change-Id: Ibf58ad6c76aaefe14fbac5b716b30c1f7c04743d
