### PR TITLE
Don't toggle tracking state on rotation

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -103,6 +103,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         intent?.let {
             if (it.getBooleanExtra("startStop", false)) {
                 onClick(findViewById(R.id.start_stop_layout))
+                it.removeExtra("startStop")
             }
         }
     }


### PR DESCRIPTION
This could happen when the quick setting tile launched the activity,
then rotation re-launched the activity with the same intent parameters,
so the tracking stopped.

As suggested in the issue, just remove the parameter once consumed.

Fixes <https://github.com/vmiklos/plees-tracker/issues/365>.

Change-Id: I9b95959fe10065008492e8aa49f9045400420ea5
