### PR TITLE
Enable editing start and end date+time of a sleep separately

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -410,6 +410,15 @@ object DataModel {
         return sdf.format(date)
     }
 
+    fun formatDateTime(date: Date, asTime: Boolean): String {
+        val sdf = if (asTime) {
+            SimpleDateFormat("HH:mm:ss", Locale.getDefault())
+        } else {
+            SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        }
+        return sdf.format(date)
+    }
+
     /**
      * Returns the subset of [sleeps] which stop after [after].
      */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepActivity.kt
@@ -24,10 +24,14 @@ class SleepActivity : AppCompatActivity(), View.OnClickListener {
         viewModel = ViewModelProvider.NewInstanceFactory().create(SleepViewModel::class.java)
 
         setContentView(R.layout.activity_sleep)
-        val start = findViewById<TextView>(R.id.sleep_start)
-        start.setOnClickListener(this)
-        val stop = findViewById<TextView>(R.id.sleep_stop)
-        stop.setOnClickListener(this)
+        val startDate = findViewById<TextView>(R.id.sleep_start_date)
+        startDate.setOnClickListener(this)
+        val startTime = findViewById<TextView>(R.id.sleep_start_time)
+        startTime.setOnClickListener(this)
+        val stopDate = findViewById<TextView>(R.id.sleep_stop_date)
+        stopDate.setOnClickListener(this)
+        val stopTime = findViewById<TextView>(R.id.sleep_stop_time)
+        stopTime.setOnClickListener(this)
 
         val bundle = intent.extras ?: return
         sid = bundle.getInt("sid")
@@ -40,8 +44,17 @@ class SleepActivity : AppCompatActivity(), View.OnClickListener {
     }
 
     override fun onClick(view: View?) {
-        val isStart = view == findViewById(R.id.sleep_start)
-        viewModel.editSleep(this, sid, isStart, applicationContext, contentResolver)
+        when {
+            view == findViewById(R.id.sleep_start_date) ->
+                viewModel.editSleepDate(this, sid, true, applicationContext, contentResolver)
+            view == findViewById(R.id.sleep_start_time) ->
+                viewModel.editSleepTime(this, sid, true, applicationContext, contentResolver)
+            view == findViewById(R.id.sleep_stop_date) ->
+                viewModel.editSleepDate(this, sid, false, applicationContext, contentResolver)
+            view == findViewById(R.id.sleep_stop_time) ->
+                viewModel.editSleepTime(this, sid, false, applicationContext, contentResolver)
+            else -> {}
+        }
     }
 }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepViewModel.kt
@@ -33,10 +33,14 @@ class SleepViewModel : ViewModel() {
         viewModelScope.launch {
             val sleep = DataModel.getSleepById(sid)
 
-            val start = activity.findViewById<TextView>(R.id.sleep_start)
-            start.text = DataModel.formatTimestamp(Date(sleep.start), DataModel.getCompactView())
-            val stop = activity.findViewById<TextView>(R.id.sleep_stop)
-            stop.text = DataModel.formatTimestamp(Date(sleep.stop), DataModel.getCompactView())
+            val startDate = activity.findViewById<TextView>(R.id.sleep_start_date)
+            startDate.text = DataModel.formatDateTime(Date(sleep.start), false)
+            val startTime = activity.findViewById<TextView>(R.id.sleep_start_time)
+            startTime.text = DataModel.formatDateTime(Date(sleep.start), true)
+            val stopDate = activity.findViewById<TextView>(R.id.sleep_stop_date)
+            stopDate.text = DataModel.formatDateTime(Date(sleep.stop), false)
+            val stopTime = activity.findViewById<TextView>(R.id.sleep_stop_time)
+            stopTime.text = DataModel.formatDateTime(Date(sleep.stop), true)
             val rating = activity.findViewById<RatingBar>(R.id.sleep_item_rating)
             rating.rating = sleep.rating.toFloat()
             rating.onRatingBarChangeListener = SleepRateCallback(viewModel, sleep)
@@ -50,7 +54,7 @@ class SleepViewModel : ViewModel() {
         }
     }
 
-    fun editSleep(
+    fun editSleepDate(
         activity: SleepActivity,
         sid: Int,
         isStart: Boolean,
@@ -59,42 +63,65 @@ class SleepViewModel : ViewModel() {
     ) {
         viewModelScope.launch {
             val sleep = DataModel.getSleepById(sid)
-
             val dateTime = Calendar.getInstance()
-            dateTime.time =
-                if (isStart) {
-                    Date(sleep.start)
-                } else {
-                    Date(sleep.stop)
-                }
+            dateTime.time = if (isStart) Date(sleep.start) else Date(sleep.stop)
+
             DatePickerDialog(
                 activity,
                 { _/*view*/, year, monthOfYear, dayOfMonth ->
                     dateTime.set(year, monthOfYear, dayOfMonth)
-                    TimePickerDialog(
-                        activity,
-                        { _/*view*/, hourOfDay, minute ->
-                            dateTime[Calendar.HOUR_OF_DAY] = hourOfDay
-                            dateTime[Calendar.MINUTE] = minute
-                            if (isStart) {
-                                sleep.start = dateTime.time.time
-                            } else {
-                                sleep.stop = dateTime.time.time
-                            }
-                            if (sleep.start < sleep.stop) {
-                                updateSleep(activity, sleep, context, cr)
-                            } else {
-                                val text = context.getString(R.string.negative_duration)
-                                val duration = Toast.LENGTH_SHORT
-                                val toast = Toast.makeText(context, text, duration)
-                                toast.show()
-                            }
-                        },
-                        dateTime[Calendar.HOUR_OF_DAY], dateTime[Calendar.MINUTE],
-                        /*is24HourView=*/DateFormat.is24HourFormat(activity)
-                    ).show()
+                    if (isStart) {
+                        sleep.start = dateTime.time.time
+                    } else {
+                        sleep.stop = dateTime.time.time
+                    }
+                    if (sleep.start < sleep.stop) {
+                        updateSleep(activity, sleep, context, cr)
+                    } else {
+                        val text = context.getString(R.string.negative_duration)
+                        val duration = Toast.LENGTH_SHORT
+                        val toast = Toast.makeText(context, text, duration)
+                        toast.show()
+                    }
                 },
                 dateTime[Calendar.YEAR], dateTime[Calendar.MONTH], dateTime[Calendar.DATE]
+            ).show()
+        }
+    }
+
+    fun editSleepTime(
+        activity: SleepActivity,
+        sid: Int,
+        isStart: Boolean,
+        context: Context,
+        cr: ContentResolver
+    ) {
+        viewModelScope.launch {
+            val sleep = DataModel.getSleepById(sid)
+            val dateTime = Calendar.getInstance()
+            dateTime.time = if (isStart) Date(sleep.start) else Date(sleep.stop)
+
+            TimePickerDialog(
+                activity,
+                { _/*view*/, hourOfDay, minute ->
+                    dateTime[Calendar.HOUR_OF_DAY] = hourOfDay
+                    dateTime[Calendar.MINUTE] = minute
+                    if (isStart) {
+                        sleep.start = dateTime.time.time
+                    } else {
+                        sleep.stop = dateTime.time.time
+                    }
+                    if (sleep.start < sleep.stop) {
+                        updateSleep(activity, sleep, context, cr)
+                    } else {
+                        val text = context.getString(R.string.negative_duration)
+                        val duration = Toast.LENGTH_SHORT
+                        val toast = Toast.makeText(context, text, duration)
+                        toast.show()
+                    }
+                },
+                dateTime[Calendar.HOUR_OF_DAY], dateTime[Calendar.MINUTE],
+                /*is24HourView=*/DateFormat.is24HourFormat(activity)
             ).show()
         }
     }

--- a/app/src/main/res/layout/activity_sleep.xml
+++ b/app/src/main/res/layout/activity_sleep.xml
@@ -64,7 +64,19 @@
 
 
             <TextView
-                android:id="@+id/sleep_start"
+                android:id="@+id/sleep_start_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="86dp"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toBottomOf="@+id/start_image"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="10:50:38" />
+
+            <TextView
+                android:id="@+id/sleep_start_time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="5dp"
@@ -100,7 +112,19 @@
 
 
             <TextView
-                android:id="@+id/sleep_stop"
+                android:id="@+id/sleep_stop_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="86dp"
+                android:textSize="16sp"
+                app:layout_constraintBottom_toBottomOf="@+id/stop_red_image"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/stop_red_image"
+                tools:text="10:50:38" />
+
+            <TextView
+                android:id="@+id/sleep_stop_time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"


### PR DESCRIPTION
Enables tap on either date **or** time when editing a sleep. Popup to modify either only the date or the time will show, instead of both one after the other.
Also see #373

_probably needs code formatting, not able to do it myself atm_