### PR TITLE
Average of daily sums: add a mode to ignore empty days

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -103,6 +103,10 @@ object DataModel {
         return preferences.getBoolean("compact_view", false)
     }
 
+    fun getIgnoreEmptyDays(): Boolean {
+        return preferences.getBoolean("ignore_empty_days", true)
+    }
+
     suspend fun storeSleep() {
         val sleep = Sleep()
         start?.let {
@@ -339,7 +343,11 @@ object DataModel {
     /**
      * Sums up sleeps per day, and then calculate the avg of those sums.
      */
-    fun getSleepDurationDailyStat(sleeps: List<Sleep>, compactView: Boolean): String {
+    fun getSleepDurationDailyStat(
+        sleeps: List<Sleep>,
+        compactView: Boolean,
+        ignoreEmptyDays: Boolean
+    ): String {
         // Day -> sum (in seconds) map.
         val sums = HashMap<Long, Long>()
         var minKey: Long = Long.MAX_VALUE
@@ -379,7 +387,10 @@ object DataModel {
         // Now determine the number of covered days. This is usually just the number of keys, but it
         // can be more, in case a whole 24h period was left out.
         val msPerDay = 86400 * 1000
-        val count = (maxKey - minKey) / msPerDay + 1
+        var count = (maxKey - minKey) / msPerDay + 1
+        if (ignoreEmptyDays) {
+            count = sums.keys.size.toLong()
+        }
         return formatDuration(sums.values.sum() / count, compactView)
     }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -181,7 +181,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
                 val durationDailyStat = stats?.findViewById<TextView>(R.id.fragment_stats_daily)
                 durationDailyStat?.text = DataModel.getSleepDurationDailyStat(
                     sleeps,
-                    DataModel.getCompactView()
+                    DataModel.getCompactView(),
+                    DataModel.getIgnoreEmptyDays()
                 )
                 sleepsAdapter.data = sleeps
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/StatsActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/StatsActivity.kt
@@ -75,7 +75,11 @@ class StatsActivity : AppCompatActivity() {
         val average = view?.findViewById<TextView>(R.id.fragment_stats_average)
         average?.text = DataModel.getSleepDurationStat(sleeps, DataModel.getCompactView())
         val daily = view?.findViewById<TextView>(R.id.fragment_stats_daily)
-        daily?.text = DataModel.getSleepDurationDailyStat(sleeps, DataModel.getCompactView())
+        daily?.text = DataModel.getSleepDurationDailyStat(
+            sleeps,
+            DataModel.getCompactView(),
+            DataModel.getIgnoreEmptyDays()
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,4 +202,5 @@
     <string name="no_sleeps">Your tracked sleeps will appear here. Press Start to create a sleep, tap on a sleep to edit it and swipe away a sleep to delete it. For more info, see the Documentation menu item.</string>
     <string name="show_average_of_sleep_duration">Show average of sleep durations</string>
     <string name="show_averege_of_daily_sums">Show average of daily sums</string>
+    <string name="ignore_empty_days">Ignore empty days when show average of daily sums</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -58,6 +58,10 @@
             android:defaultValue="true"
             android:key="show_average_daily_sums"
             android:title="@string/show_averege_of_daily_sums" />
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="ignore_empty_days"
+            android:title="@string/ignore_empty_days" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/past_sleeps">

--- a/app/src/test/java/hu/vmiklos/plees_tracker/DataModelUnitTest.kt
+++ b/app/src/test/java/hu/vmiklos/plees_tracker/DataModelUnitTest.kt
@@ -98,7 +98,7 @@ class DataModelUnitTest {
         // Note how this is 11, not 5.5.
         assertEquals(
             "0:00:11",
-            DataModel.getSleepDurationDailyStat(sleeps, false)
+            DataModel.getSleepDurationDailyStat(sleeps, false, false)
         )
     }
 
@@ -127,7 +127,42 @@ class DataModelUnitTest {
         // Note how this is 8 hours per day, not 12.
         assertEquals(
             "8:00:00",
-            DataModel.getSleepDurationDailyStat(sleeps, false)
+            DataModel.getSleepDurationDailyStat(sleeps, false, false)
+        )
+    }
+
+    @Test
+    fun testAvgOfDailySumsIgnoreEmptyDays() {
+        val sleeps = ArrayList<Sleep>()
+        val calendar = Calendar.getInstance()
+        calendar.timeInMillis = 0
+
+        // 5+1 hours on 12th
+        var sleep = Sleep()
+        calendar.set(2020, 2, 12, 0, 0, 0)
+        sleep.start = calendar.timeInMillis
+        calendar.set(2020, 2, 12, 5, 0, 0)
+        sleep.stop = calendar.timeInMillis
+        sleeps.add(sleep)
+        sleep = Sleep()
+        calendar.set(2020, 2, 12, 6, 0, 0)
+        sleep.start = calendar.timeInMillis
+        calendar.set(2020, 2, 12, 7, 0, 0)
+        sleep.stop = calendar.timeInMillis
+        sleeps.add(sleep)
+
+        // 7 hours on 14th
+        sleep = Sleep()
+        calendar.set(2020, 2, 14, 0, 0, 0)
+        sleep.start = calendar.timeInMillis
+        calendar.set(2020, 2, 14, 7, 0, 0)
+        sleep.stop = calendar.timeInMillis
+        sleeps.add(sleep)
+
+        // Note how this is 6.5 hours per day, not 4.33.
+        assertEquals(
+            "6:30:00",
+            DataModel.getSleepDurationDailyStat(sleeps, false, true)
         )
     }
 

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -82,6 +82,11 @@ The 'Show average of daily sums' setting is enabled by default and is useful if 
 your sleeps, but you may sleep multiple times a day. This will first count the sum of your sleeps
 within a day, and count the average of those sums.
 
+The 'Ignore empty days when show average of daily sums' setting by default ignores empty days when
+counting the average of daily sums, assuming that you probably just forgot to track your sleep(s) on
+that day. If this is not the case and you in fact sometimes skip an entire day, then disable this
+setting.
+
 ### Past sleeps
 
 The past sleeps section allow configuring the contents of the individual sleep cards:


### PR DESCRIPTION
And enable it by default, see the guide for rationale.

Fixes <https://github.com/vmiklos/plees-tracker/issues/366>.

Change-Id: Ie09db97d72eafbdfbe665ce818133d5a0df5ee03
