### PR TITLE
Export to file: avoid reporting success in toast on failure

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -287,24 +287,32 @@ object DataModel {
             Log.e(TAG, "exportData: takePersistableUriPermission() failed for write")
         }
 
-        val os: OutputStream? = cr.openOutputStream(uri)
-        if (os == null) {
-            Log.e(TAG, "exportData: openOutputStream() failed")
-            return
-        }
+        var os: OutputStream? = null
         try {
+            os = cr.openOutputStream(uri)
+            if (os == null) {
+                Log.e(TAG, "exportData: openOutputStream() failed")
+                return
+            }
             val writer = CSVPrinter(OutputStreamWriter(os, "UTF-8"), CSVFormat.DEFAULT)
             writer.printRecord("sid", "start", "stop", "rating", "comment")
             for (sleep in sleeps) {
                 writer.printRecord(sleep.sid, sleep.start, sleep.stop, sleep.rating, sleep.comment)
             }
             writer.close()
-        } catch (e: IOException) {
-            Log.e(TAG, "exportData: write() failed")
+        } catch (e: Exception) {
+            if (showToast) {
+                val text = String.format(context.getString(R.string.export_failure), e)
+                val duration = Toast.LENGTH_SHORT
+                val toast = Toast.makeText(context, text, duration)
+                toast.show()
+            } else {
+                Log.e(TAG, "exportDataToFile, failed: $e")
+            }
             return
         } finally {
             try {
-                os.close()
+                os?.close()
             } catch (_: Exception) {
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="export_calendar_item">Export to Calendar</string>
     <string name="import_success">Import finished successfully</string>
     <string name="export_success">Export finished successfully</string>
+    <string name="export_failure">Export failed: %s</string>
     <string name="sleeping_since">Sleeping since %s</string>
     <string name="past">Past sleeps</string>
     <string name="tracking_stopped">Tracking stopped</string>


### PR DESCRIPTION
It turns out openOutputStream() can throw an exception, which is not
obvious at first, since it returns a nullable output stream, so first I
assumed that it returns a null output stream on failure.

Also, given that it was assumed export can't reach showing a toast on
failure, we always presented success. Fix this and report an error on
failure.

Fixes <https://github.com/vmiklos/plees-tracker/issues/406>.

Change-Id: Ic5922e4b38f544debe0888bd636d21be8fe35f49
