### PR TITLE
build: Add debug suffix variant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,7 @@ android {
         kotlinOptions.allWarningsAsErrors = true
     }
     compileSdk 33
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "hu.vmiklos.plees_tracker"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
         kotlinOptions.allWarningsAsErrors = true
     }
     compileSdk 33
-    buildToolsVersion "30.0.3"
+
     defaultConfig {
         applicationId "hu.vmiklos.plees_tracker"
         minSdkVersion 23
@@ -30,6 +30,9 @@ android {
         }
     }
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
The first change removes the line, as it is ignored anyway and has no meaning anymore.

The second change changes the suffix of the debug variant – you can have both the debug and release variants installed at the same time – you can track your own sleep in the production variant and do experiment in the debug one. I can also change app label/icon color in the debug variant if you want, so it can be distinguished more easily. If you don't want this change, I understand, but it's generally really useful.