### PR TITLE
import file: handle when the storage is in fact a network one

### DIFF
--- a/guide/src/hacking.md
+++ b/guide/src/hacking.md
@@ -32,3 +32,15 @@ If you are used to Java, then not spelling out type names all over the place is 
 See
 <https://stackoverflow.com/questions/54851861/how-do-i-activate-type-annotations-hints-in-kotlin-like-depicted>
 on how to let Android Studio show these types for you without polluting the code.
+
+## Debugging
+
+You are supposed to go via the Android logging framework, one possible (temporary, local) debug
+printf:
+
+```kotlin
+Log.e(TAG, "debug, myFunc: myVar is " + myVar)
+```
+
+This way it stands out from the stock debug messages when you filter for `package:mine` in the
+Logcat tab in Android Studio.


### PR DESCRIPTION
Import from file is normally a non-blocking operation, so it can be done
on the UI, except when going via the storage access framework, e.g. when
the file is provided by nextcloud. This resulted in a crash like:

	2023-10-13 22:10:48.342  7896-7896  AndroidRuntime          hu.vmiklos.plees_tracker.debug       E  FATAL EXCEPTION: main
	    at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:153)
	    at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:814)
	    at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:2043)
	    at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1858)
	    at android.content.ContentResolver.openInputStream(ContentResolver.java:1528)
	    at hu.vmiklos.plees_tracker.DataModel.importData(DataModel.kt:163)

The NetworkOnMainThreadException is thrown because we actually do
networking on the main thread, but that should be done on a thread to
not block the UI.

Fix the problem by wrapping the IO part of importData() in a
`withContext(Dispatchers.IO)` block, but keep the toast on the main
thread, as UI calls are only allowed on the main thread.

Fixes <https://github.com/vmiklos/plees-tracker/issues/407>.

Change-Id: Ia9d691fd178c343554ede86c39a801134f2aab2e
