### PR TITLE
Fix no action on pressing the back button on the action bar

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/GraphsActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/GraphsActivity.kt
@@ -45,6 +45,10 @@ class GraphsActivity : AppCompatActivity() {
             R.id.graph_stop -> renderStopChart()
             R.id.graph_rating -> renderRatingChart()
             R.id.graph_variance -> renderVarianceChart()
+            android.R.id.home -> {
+                this.finish()
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepActivity.kt
@@ -7,6 +7,7 @@
 package hu.vmiklos.plees_tracker
 
 import android.os.Bundle
+import android.view.MenuItem
 import android.view.View
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -55,6 +56,14 @@ class SleepActivity : AppCompatActivity(), View.OnClickListener {
                 viewModel.editSleepTime(this, sid, false, applicationContext, contentResolver)
             else -> {}
         }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            this.finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
     }
 }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/StatsActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/StatsActivity.kt
@@ -7,6 +7,7 @@
 package hu.vmiklos.plees_tracker
 
 import android.os.Bundle
+import android.view.MenuItem
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
@@ -80,6 +81,14 @@ class StatsActivity : AppCompatActivity() {
             DataModel.getCompactView(),
             DataModel.getIgnoreEmptyDays()
         )
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            this.finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
     }
 }
 

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+- Fix no action on pressing the back button on the action bar
+
 ## 7.6.4
 
 - Target Android 14


### PR DESCRIPTION
Pressing the back button on the action bar of these 3 activities
resulted in no action.

At some point in the past, just calling setDisplayHomeAsUpEnabled(true)
was enough, but looks like these days nothing happens by default.

Fix the problem by explicitly handling android.R.id.home and there
finishing the current activity.
