### PR TITLE
Added Themed / Monochrome Launcher icon support for devices that support it

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Starting with TargetSDK 33, Launchers can call for an app's monochrome icon variant to create a themed version from a color palette based on the wallpaper or the user's preference.

## Examples

### Yellow Palette, Light Mode

![scr1_yellow_light](https://github.com/vmiklos/plees-tracker/assets/57289288/07efc574-6094-4f3b-9638-daf4097b09b2)

### Blue Palette, Dark Mode

![scr2_blue_dark](https://github.com/vmiklos/plees-tracker/assets/57289288/6ab734fa-6b7b-4c1a-afd9-d0b5af320e8f)
