### PR TITLE
Add DND (Do Not Disturb) Integration

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <value>
+      <entry key="app">
+        <State />
+      </entry>
+    </value>
+  </component>
+</project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -14,7 +14,6 @@ import android.content.pm.PackageManager
 import android.content.res.ColorStateList
 import android.net.Uri
 import android.os.Bundle
-import android.provider.Settings
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -323,7 +323,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
             // When user stops tracking sleep
             if (dndManager.isNotificationPolicyAccessGranted and dndEnabled) {
                 // Restore Do Not Disturb status when user started tracking
-                dndManager.setInterruptionFilter(preferences.getInt("current_dnd", NotificationManager.INTERRUPTION_FILTER_ALL))
+                dndManager.setInterruptionFilter(preferences.getInt("current_dnd",
+                    NotificationManager.INTERRUPTION_FILTER_ALL))
             } else {
                 Log.w(TAG, "Failed to disable DND, permissions not enabled")
             }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -341,8 +341,6 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
             if (dndManager.isNotificationPolicyAccessGranted) {
                 dndManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_NONE)
             } else {
-                val intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
-                startActivity(intent)
                 Log.w(TAG, "Failed to enable DND, permissions not enabled")
             }
             status.text = String.format(

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -323,8 +323,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
             // When user stops tracking sleep
             if (dndManager.isNotificationPolicyAccessGranted and dndEnabled) {
                 // Restore Do Not Disturb status when user started tracking
-                dndManager.setInterruptionFilter(preferences.getInt("current_dnd",
-                    NotificationManager.INTERRUPTION_FILTER_ALL))
+                val filterAll = NotificationManager.INTERRUPTION_FILTER_ALL
+                dndManager.setInterruptionFilter(preferences.getInt("current_dnd", filterAll))
             } else {
                 Log.w(TAG, "Failed to disable DND, permissions not enabled")
             }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
@@ -9,13 +9,10 @@ package hu.vmiklos.plees_tracker
 import android.app.AlertDialog
 import android.app.NotificationManager
 import android.content.Context
-import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
@@ -93,8 +90,8 @@ class Preferences : PreferenceFragmentCompat() {
                 editor.apply()
                 Log.d(TAG, "Set enable_dnd to false!")
                 // Refresh screen, not the "cleanest way" but it works
-                preferenceScreen.removeAll();
-                addPreferencesFromResource(R.xml.preferences);
+                preferenceScreen.removeAll()
+                addPreferencesFromResource(R.xml.preferences)
             } else {
                 Log.wtf(TAG, "editor is null")
             }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
@@ -38,7 +38,8 @@ class Preferences : PreferenceFragmentCompat() {
             if (sharedPreferences != null) {
                 if (sharedPreferences.getBoolean("enable_dnd", false)) {
                     val activity = activity ?: return super.onPreferenceTreeClick(preference)
-                    val dndManager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                    val dndManager = activity.getSystemService(Context.NOTIFICATION_SERVICE)
+                            as NotificationManager
                     val hasPermission = dndManager.isNotificationPolicyAccessGranted
 
                     if (!hasPermission) {
@@ -46,11 +47,14 @@ class Preferences : PreferenceFragmentCompat() {
                         AlertDialog.Builder(context)
                             .setTitle(R.string.settings_enable_dnd_question_title)
                             .setMessage(R.string.settings_enable_dnd_question_message)
-                            .setPositiveButton(R.string.settings_enable_dnd_question_ok) { _, _ ->
-                                val intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+                            .setPositiveButton(
+                                R.string.settings_enable_dnd_question_ok) { _, _ ->
+                                val intent = Intent(
+                                    Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
                                 startActivity(intent)
                             }
-                            .setNegativeButton(R.string.settings_enable_dnd_question_cancel) { _, _ ->
+                            .setNegativeButton(
+                                R.string.settings_enable_dnd_question_cancel) { _, _ ->
                                 val editor = sharedPreferences.edit()
                                 if (editor != null) {
                                     editor.putBoolean("enable_dnd", false)
@@ -78,7 +82,8 @@ class Preferences : PreferenceFragmentCompat() {
 
     fun checkDnd() {
         val activity = activity ?: return
-        val dndManager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val dndManager = activity.getSystemService(Context.NOTIFICATION_SERVICE)
+                as NotificationManager
         val hasPermission = dndManager.isNotificationPolicyAccessGranted
 
         val sharedPreferences = context?.let { PreferenceManager.getDefaultSharedPreferences(it) }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
@@ -38,23 +38,21 @@ class Preferences : PreferenceFragmentCompat() {
             if (sharedPreferences != null) {
                 if (sharedPreferences.getBoolean("enable_dnd", false)) {
                     val activity = activity ?: return super.onPreferenceTreeClick(preference)
-                    val dndManager = activity.getSystemService(Context.NOTIFICATION_SERVICE)
-                            as NotificationManager
+                    val noteServ = Context.NOTIFICATION_SERVICE // 100 char limit
+                    val dndManager = activity.getSystemService(noteServ) as NotificationManager
                     val hasPermission = dndManager.isNotificationPolicyAccessGranted
 
                     if (!hasPermission) {
                         // If we don't have permissions for DND
                         AlertDialog.Builder(context)
-                            .setTitle(R.string.settings_enable_dnd_question_title)
-                            .setMessage(R.string.settings_enable_dnd_question_message)
-                            .setPositiveButton(
-                                R.string.settings_enable_dnd_question_ok) { _, _ ->
-                                val intent = Intent(
-                                    Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+                            .setTitle(R.string.settings_enable_dnd_q_title)
+                            .setMessage(R.string.settings_enable_dnd_q_message)
+                            .setPositiveButton(R.string.settings_enable_dnd_q_ok) { _, _ ->
+                                val setting_id = Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS
+                                val intent = Intent(setting_id)
                                 startActivity(intent)
                             }
-                            .setNegativeButton(
-                                R.string.settings_enable_dnd_question_cancel) { _, _ ->
+                            .setNegativeButton(R.string.settings_enable_dnd_q_cancel) { _, _ ->
                                 val editor = sharedPreferences.edit()
                                 if (editor != null) {
                                     editor.putBoolean("enable_dnd", false)
@@ -82,8 +80,8 @@ class Preferences : PreferenceFragmentCompat() {
 
     fun checkDnd() {
         val activity = activity ?: return
-        val dndManager = activity.getSystemService(Context.NOTIFICATION_SERVICE)
-                as NotificationManager
+        val noteServ = Context.NOTIFICATION_SERVICE // 100 char limit
+        val dndManager = activity.getSystemService(noteServ) as NotificationManager
         val hasPermission = dndManager.isNotificationPolicyAccessGranted
 
         val sharedPreferences = context?.let { PreferenceManager.getDefaultSharedPreferences(it) }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
@@ -6,11 +6,24 @@
 
 package hu.vmiklos.plees_tracker
 
+import android.app.AlertDialog
+import android.app.NotificationManager
+import android.content.Context
+import android.content.DialogInterface
+import android.content.Intent
 import android.os.Bundle
+import android.provider.Settings
+import android.util.Log
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.PreferenceManager
 
 class Preferences : PreferenceFragmentCompat() {
+    companion object {
+        private const val TAG = "PreferencesActivity"
+    }
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
         val autoBackupPath = findPreference<Preference>("auto_backup_path")
@@ -18,6 +31,73 @@ class Preferences : PreferenceFragmentCompat() {
             val preferences = DataModel.preferences
             val path = preferences.getString("auto_backup_path", "")
             it.summary = path
+        }
+    }
+
+    override fun onPreferenceTreeClick(preference: Preference): Boolean {
+        val sharedPreferences = context?.let { PreferenceManager.getDefaultSharedPreferences(it) }
+
+        if (preference.key == "enable_dnd") { // If someone toggled the enable_dnd preference
+            if (sharedPreferences != null) {
+                if (sharedPreferences.getBoolean("enable_dnd", false)) {
+                    val activity = activity ?: return super.onPreferenceTreeClick(preference)
+                    val dndManager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                    val hasPermission = dndManager.isNotificationPolicyAccessGranted
+
+                    if (!hasPermission) {
+                        // If we don't have permissions for DND
+                        AlertDialog.Builder(context)
+                            .setTitle(R.string.settings_enable_dnd_question_title)
+                            .setMessage(R.string.settings_enable_dnd_question_message)
+                            .setPositiveButton(R.string.settings_enable_dnd_question_ok) { _, _ ->
+                                val intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+                                startActivity(intent)
+                            }
+                            .setNegativeButton(R.string.settings_enable_dnd_question_cancel) { _, _ ->
+                                val editor = sharedPreferences.edit()
+                                if (editor != null) {
+                                    editor.putBoolean("enable_dnd", false)
+                                    editor.apply()
+                                } else {
+                                    Log.wtf(TAG, "editor is null")
+                                }
+                                checkDnd()
+                            }
+                            .create()
+                            .show()
+                    }
+                }
+            } else {
+                Log.wtf(TAG, "sharedPreferences is null")
+            }
+        }
+        return super.onPreferenceTreeClick(preference)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        checkDnd()
+    }
+
+    fun checkDnd() {
+        val activity = activity ?: return
+        val dndManager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val hasPermission = dndManager.isNotificationPolicyAccessGranted
+
+        val sharedPreferences = context?.let { PreferenceManager.getDefaultSharedPreferences(it) }
+        val editor = sharedPreferences?.edit()
+
+        if (!hasPermission) {
+            if (editor != null) {
+                editor.putBoolean("enable_dnd", false)
+                editor.apply()
+                Log.d(TAG, "Set enable_dnd to false!")
+                // Refresh screen, not the "cleanest way" but it works
+                preferenceScreen.removeAll();
+                addPreferencesFromResource(R.xml.preferences);
+            } else {
+                Log.wtf(TAG, "editor is null")
+            }
         }
     }
 }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -6,11 +6,15 @@
 
 package hu.vmiklos.plees_tracker
 
+import android.app.NotificationManager
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import android.provider.Settings
+import androidx.activity.result.ActivityResultLauncher
 
 class PreferencesActivity : AppCompatActivity() {
     companion object {
@@ -19,6 +23,7 @@ class PreferencesActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // To my knowledge you have to use getSystemService in activity code
         supportFragmentManager
             .beginTransaction()
             .replace(R.id.settings_container, Preferences())

--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -6,15 +6,11 @@
 
 package hu.vmiklos.plees_tracker
 
-import android.app.NotificationManager
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import android.provider.Settings
-import androidx.activity.result.ActivityResultLauncher
 
 class PreferencesActivity : AppCompatActivity() {
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,10 +65,10 @@
     <string name="settings_dashboard_duration">Duration</string>
     <string name="settings_etc">Miscellaneous</string>
     <string name="settings_enable_dnd">Do not disturb when tracking</string>
-    <string name="settings_enable_dnd_question_title">Permissions Required</string>
-    <string name="settings_enable_dnd_question_message">Please allow Do Not Disturb permissions for this app on the next screen.</string>
-    <string name="settings_enable_dnd_question_ok">OK</string>
-    <string name="settings_enable_dnd_question_cancel">Cancel</string>
+    <string name="settings_enable_dnd_q_title">Permissions Required</string>
+    <string name="settings_enable_dnd_q_message">Please allow Do Not Disturb permissions for this app on the next screen.</string>
+    <string name="settings_enable_dnd_q_ok">OK</string>
+    <string name="settings_enable_dnd_q_cancel">Cancel</string>
     <string name="last_week">Last week</string>
     <string name="last_two_weeks">Last two weeks</string>
     <string name="last_month">Last month</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,12 @@
     <string name="widget_start_stop">Toggle tracking</string>
     <string name="settings_category_dashboard">Dashboard</string>
     <string name="settings_dashboard_duration">Duration</string>
+    <string name="settings_etc">Miscellaneous</string>
+    <string name="settings_enable_dnd">Do not disturb when tracking</string>
+    <string name="settings_enable_dnd_question_title">Permissions Required</string>
+    <string name="settings_enable_dnd_question_message">Please allow Do Not Disturb permissions for this app on the next screen.</string>
+    <string name="settings_enable_dnd_question_ok">OK</string>
+    <string name="settings_enable_dnd_question_cancel">Cancel</string>
     <string name="last_week">Last week</string>
     <string name="last_two_weeks">Last two weeks</string>
     <string name="last_month">Last month</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -74,5 +74,14 @@
             android:key="show_rating"
             android:title="@string/show_rating" />
     </PreferenceCategory>
+    <PreferenceCategory
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:title="@string/settings_etc">
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="enable_dnd"
+            android:title="@string/settings_enable_dnd" />
+    </PreferenceCategory>
 </PreferenceScreen>
 

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -99,6 +99,12 @@ The past sleeps section allow configuring the contents of the individual sleep c
 The sleep cards are not re-created when changing settings, so you need to restart plees-tracker to
 see the effect.
 
+### Do not disturb when tracking
+
+This option enables automatic activation of DND (Do Not Disturb) mode when you start tracking your sleep. When toggled on for the first time, you will be prompted to grant Plees Tracker permissions to modify DND settings.
+
+Upon ceasing sleep tracking, the DND setting you had enabled prior to initiating the tracking will be restored.
+
 ## Sleep activity
 
 The sleep activity allows modifying the start,  stop time or rating of a single recorded sleep,


### PR DESCRIPTION
This pull request adds these following changes to the app:

- Do not disturb integration, when the user starts tracking their sleep the app turns DND mode automatically and turns it to the last state the user left DND on when they stop tracking sleep
- Added DND setting to the preferences, it also asks the user for the DND permission which is required for DND integration to work.

This might not be the perfect way to do this but it does seem to work well for me at least (on emulator and real phone), and this pull request also solves issue #419