### PR TITLE
main activity: fix missing update after changing the rating of a sleep

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/Sleep.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Sleep.kt
@@ -40,7 +40,8 @@ class Sleep {
     override fun equals(other: Any?): Boolean =
         other is Sleep &&
             other.start == start &&
-            other.stop == stop
+            other.stop == stop &&
+            other.rating == rating
 
     override fun hashCode(): Int {
         var result = start.hashCode()

--- a/app/src/test/java/hu/vmiklos/plees_tracker/SleepUnitTest.kt
+++ b/app/src/test/java/hu/vmiklos/plees_tracker/SleepUnitTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package hu.vmiklos.plees_tracker
+
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Unit tests for Sleep.
+ */
+class SleepUnitTest {
+    @Test
+    fun testEquals() {
+        val sleep1 = Sleep()
+        sleep1.rating = 1
+        val sleep2 = Sleep()
+        sleep2.rating = 2
+        assertNotEquals(sleep1, sleep2)
+    }
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
This is called from areContentsTheSame() in SleepsAdapter.kt.

Fixes <https://github.com/vmiklos/plees-tracker/issues/455>.
