### PR TITLE
Add option to use median instead of average

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -184,7 +184,8 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
                 durationDailyStat?.text = DataModel.getSleepDurationDailyStat(
                     sleeps,
                     DataModel.getCompactView(),
-                    DataModel.getIgnoreEmptyDays()
+                    DataModel.getIgnoreEmptyDays(),
+                    DataModel.getStatFunction()
                 )
                 sleepsAdapter.data = sleeps
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Median.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Median.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 The Algorithms
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package hu.vmiklos.plees_tracker
+
+import java.util.Arrays.sort
+
+/**
+ * Calculates the median of an array of Int
+ *
+ * @param values is an array of Int
+ * @return the middle number of the array
+ */
+fun median(values: LongArray): Double {
+    sort(values)
+    return when {
+        values.size % 2 == 0 -> getHalfwayBetweenMiddleValues(values)
+        else -> getMiddleValue(values)
+    }
+}
+
+/**
+ * Calculates the middle number of an array when the size is an even number
+ *
+ * @param values is an array of Int
+ * @return the middle number of the array
+ */
+private fun getHalfwayBetweenMiddleValues(values: LongArray): Double {
+    val arraySize = values.size
+    val sumOfMiddleValues = (values[arraySize / 2] + values[(arraySize / 2) - 1 ])
+    return sumOfMiddleValues / 2.0
+}
+
+/**
+ * Calculates the middle number of an array when the size is an odd number
+ *
+ * @param values is an array of Int
+ * @return the middle number of the array
+ */
+private fun getMiddleValue(values: LongArray): Double {
+    return values[values.size / 2].toDouble()
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/StatsActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/StatsActivity.kt
@@ -79,7 +79,8 @@ class StatsActivity : AppCompatActivity() {
         daily?.text = DataModel.getSleepDurationDailyStat(
             sleeps,
             DataModel.getCompactView(),
-            DataModel.getIgnoreEmptyDays()
+            DataModel.getIgnoreEmptyDays(),
+            DataModel.getStatFunction()
         )
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,4 +221,5 @@
     <string name="show_average_of_sleep_duration">Show average of sleep durations</string>
     <string name="show_averege_of_daily_sums">Show average of daily sums</string>
     <string name="ignore_empty_days">Ignore empty days when showing average of daily sums</string>
+    <string name="use_median">Use median instead of average when counting the daily duration</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -62,6 +62,10 @@
             android:defaultValue="true"
             android:key="ignore_empty_days"
             android:title="@string/ignore_empty_days" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="use_median"
+            android:title="@string/use_median" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/past_sleeps">

--- a/app/src/test/java/hu/vmiklos/plees_tracker/DataModelUnitTest.kt
+++ b/app/src/test/java/hu/vmiklos/plees_tracker/DataModelUnitTest.kt
@@ -114,9 +114,10 @@ class DataModelUnitTest {
         sleeps.add(sleep)
 
         // Note how this is 11, not 5.5.
+        val func = DataModel.StatFunction.AVERAGE
         assertEquals(
             "0:00:11",
-            DataModel.getSleepDurationDailyStat(sleeps, false, false)
+            DataModel.getSleepDurationDailyStat(sleeps, false, false, func)
         )
     }
 
@@ -143,9 +144,47 @@ class DataModelUnitTest {
         sleeps.add(sleep)
 
         // Note how this is 8 hours per day, not 12.
+        val func = DataModel.StatFunction.AVERAGE
         assertEquals(
             "8:00:00",
-            DataModel.getSleepDurationDailyStat(sleeps, false, false)
+            DataModel.getSleepDurationDailyStat(sleeps, false, false, func)
+        )
+    }
+
+    @Test
+    fun testMedianOfDailySums() {
+        val sleeps = ArrayList<Sleep>()
+        val calendar = Calendar.getInstance()
+        calendar.timeInMillis = 0
+
+        // 5 hours on 12th
+        var sleep = Sleep()
+        calendar.set(2020, 2, 12, 0, 0, 0)
+        sleep.start = calendar.timeInMillis
+        calendar.set(2020, 2, 12, 5, 0, 0)
+        sleep.stop = calendar.timeInMillis
+        sleeps.add(sleep)
+
+        // 8 hours on 13th
+        sleep = Sleep()
+        calendar.set(2020, 2, 13, 0, 0, 0)
+        sleep.start = calendar.timeInMillis
+        calendar.set(2020, 2, 13, 8, 0, 0)
+        sleep.stop = calendar.timeInMillis
+        sleeps.add(sleep)
+
+        // 9 hours on 14th
+        sleep = Sleep()
+        calendar.set(2020, 2, 14, 0, 0, 0)
+        sleep.start = calendar.timeInMillis
+        calendar.set(2020, 2, 14, 9, 0, 0)
+        sleep.stop = calendar.timeInMillis
+        sleeps.add(sleep)
+
+        // Note how this is 8, not 7 hours.
+        assertEquals(
+            "8:00:00",
+            DataModel.getSleepDurationDailyStat(sleeps, false, true, DataModel.StatFunction.MEDIAN)
         )
     }
 
@@ -180,7 +219,7 @@ class DataModelUnitTest {
         // Note how this is 6.5 hours per day, not 4.33.
         assertEquals(
             "6:30:00",
-            DataModel.getSleepDurationDailyStat(sleeps, false, true)
+            DataModel.getSleepDurationDailyStat(sleeps, false, true, DataModel.StatFunction.AVERAGE)
         )
     }
 

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -87,6 +87,11 @@ empty days when counting the average of daily sums, assuming that you probably j
 your sleep(s) on that day. If this is not the case and you in fact sometimes skip an entire day,
 then disable this setting.
 
+The 'Use median instead of average when counting the daily duration' setting is disabled by default
+and uses median instead of average when showing a single duration for the daily sum of several days.
+This is less expected, but can be useful in case you filter out e.g. sick days where one may
+undersleep or oversleep.
+
 ### Past sleeps
 
 The past sleeps section allow configuring the contents of the individual sleep cards:


### PR DESCRIPTION
Median code is a separate file to have the correct header, from
<https://github.com/TheAlgorithms/Kotlin/blob/master/src/main/kotlin/math/Median.kt>.

Fixes <https://github.com/vmiklos/plees-tracker/issues/437>.
