### PR TITLE
test: resolve FIXME in sleep create test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
+    androidTestImplementation "androidx.test.uiautomator:uiautomator:2.3.0"
     def room_version = "2.6.1"
     implementation "androidx.room:room-runtime:$room_version"
     ksp "androidx.room:room-compiler:$room_version"

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityInstrumentedTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityInstrumentedTest.kt
@@ -16,14 +16,11 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import androidx.test.espresso.action.ViewActions.click
-// import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
-import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import java.io.File
 import java.time.Duration
@@ -33,14 +30,12 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
-import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
 
 /**
  * Instrumented tests for MainActivity.
  */
-@RunWith(AndroidJUnit4::class)
+// @RunWith(AndroidJUnit4::class)
 class MainActivityInstrumentedTest {
 
     @JvmField
@@ -67,21 +62,6 @@ class MainActivityInstrumentedTest {
     fun cleanup() {
         database.close()
         Intents.release()
-    }
-
-    @Test
-    fun testCountStat(): Unit = runBlocking {
-        val startStop = onView(withId(R.id.start_stop_layout))
-        // Start.
-        startStop.perform(click())
-        // Stop.
-        startStop.perform(click())
-
-        // Read number of created sleeps.
-        assertEquals(1, database.sleepDao().getAll().size)
-        // FIXME UI is not yet updated, how to wait for this?
-        // val sleepsCount = onView(withId(R.id.fragment_stats_sleeps))
-        // sleepsCount.check(matches(withText("1")))
     }
 
     // FIXME started to fail with: java.lang.AssertionError: expected:<1> but was:<0>

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityUITest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityUITest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package hu.vmiklos.plees_tracker
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * UI tests for MainActivity.
+ */
+@RunWith(AndroidJUnit4::class)
+class MainActivityUITest {
+    @JvmField
+    @Rule
+    var activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun testCreate() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val device = UiDevice.getInstance(instrumentation)
+        val pkg = instrumentation.processName
+        val timeout: Long = 5000
+
+        val startStop = device.wait(Until.findObject(By.res(pkg, "start_stop")), timeout)
+        startStop.click()
+        startStop.click()
+
+        val sleeps = device.wait(
+            Until.findObject(By.res(pkg, "fragment_stats_sleeps").text("1")),
+            timeout
+        )
+        assertNotNull(sleeps)
+    }
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Try the uiautomator approach, espresso doesn't seem to be able to cope
with the coroutines/room/observer-based UI updates.
