### PR TITLE
CI: restore taking key store settings from secrets

### DIFF
--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -10,8 +10,7 @@
 #
 
 mkdir -p app/keystore/
-# TODO get this working on Linux
-if [ -n "$KEYSTORE" -a `uname` != Linux ]; then
+if [ -n "$KEYSTORE" ]; then
     echo "$KEYSTORE" | base64 -d > app/keystore/plees_keystore.jks
 fi
 


### PR DESCRIPTION
The root of the problem was not quoting the arg of "echo" when writing
the base64 of the .jks, but by the time I figured this out, I lost the
old value of the KEYSTORE secret, so re-generate all 4 and try to
re-enable this.
