### PR TITLE
test: avoid going via the UI in createSleep()

### DIFF
--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityUITest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityUITest.kt
@@ -32,6 +32,7 @@ class MainActivityUITest : UITestBase() {
         // When creating one:
         val startStop = findObjectByRes("start_stop")
         startStop.click()
+        Thread.sleep(1)
         startStop.click()
 
         // Then make sure we have one sleep:

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/SleepActivityUITest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/SleepActivityUITest.kt
@@ -37,12 +37,6 @@ class SleepActivityUITest : UITestBase() {
         findObjectByDesc("10").click()
         findObjectByDesc("0").click()
         findObjectByText("OK").click()
-        // In case the start was not updated (to prevent negative sleep length), do it again:
-        findObjectByRes("sleep_start_time").click()
-        findObjectByText("AM").click()
-        findObjectByDesc("10").click()
-        findObjectByDesc("0").click()
-        findObjectByText("OK").click()
 
         assertResText("sleep_start_time", "10:00")
         assertResText("sleep_stop_time", "22:00")

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/UITestBase.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/UITestBase.kt
@@ -11,10 +11,12 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
+import java.util.Calendar
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 
 open class UITestBase {
-    protected val timeout: Long = 5000
+    private val timeout: Long = 5000
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
     protected val pkg = instrumentation.processName
     protected val device = UiDevice.getInstance(instrumentation)
@@ -48,9 +50,17 @@ open class UITestBase {
     }
 
     protected fun createSleep() {
-        val startStop = findObjectByRes("start_stop")
-        startStop.click()
-        startStop.click()
+        val sleep = Sleep()
+        val start = Calendar.getInstance()
+        start.set(Calendar.HOUR_OF_DAY, 9)
+        sleep.start = start.timeInMillis
+        val stop = Calendar.getInstance()
+        start.set(Calendar.HOUR_OF_DAY, 23)
+        sleep.stop = stop.timeInMillis
+        runBlocking {
+            DataModel.database.sleepDao().insert(sleep)
+        }
+        device.waitForIdle()
     }
 }
 


### PR DESCRIPTION
This is used only during setup, not part of the actual "when" action of
the UI tests. Also means that testUpdate() can now set the start of the
sleep only once, since the original start/stop value can be controlled.
