### PR TITLE
test: clean up getResText() with its hint argument

### DIFF
--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityUITest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityUITest.kt
@@ -46,13 +46,15 @@ class MainActivityUITest : UITestBase() {
 
     @Test
     fun testRead() {
-        // Given no sleeps:
+        // Given no sleeps and creating one:
         resetDatabase()
         createSleep()
 
-        val text = getResText("fragment_stats_sleeps", "1")
+        // When waiting for 'SELECT' to be executed:
+        device.waitForIdle()
 
-        assertEquals(text, "1")
+        // Then make sure the sleep count widget reads the correct value:
+        assertResText("fragment_stats_sleeps", "1")
     }
 
     @Test

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/UITestBase.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/UITestBase.kt
@@ -33,15 +33,10 @@ open class UITestBase {
         return device.wait(Until.findObject(By.desc(desc)), timeout)
     }
 
-    protected fun getResText(resourceId: String, hint: String): String {
-        device.wait(Until.findObject(By.res(pkg, resourceId).text(hint)), timeout)
-        val obj = device.findObject(By.res(pkg, resourceId))
-        return obj.text
-    }
-
     protected fun assertResText(resourceId: String, textValue: String) {
-        val text = getResText(resourceId, textValue)
-        assertEquals(textValue, text)
+        device.wait(Until.findObject(By.res(pkg, resourceId).text(textValue)), timeout)
+        val obj = device.findObject(By.res(pkg, resourceId))
+        assertEquals(textValue, obj.text)
     }
 
     protected fun resetDatabase() {


### PR DESCRIPTION
Best to always do the "wait for text + assert" in one go, and it's less
code this way.
