### PR TITLE
UITestBase: pkg can be private

### DIFF
--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/UITestBase.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/UITestBase.kt
@@ -18,7 +18,7 @@ import org.junit.Assert.assertEquals
 open class UITestBase {
     private val timeout: Long = 5000
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
-    protected val pkg = instrumentation.processName
+    private val pkg = instrumentation.processName
     protected val device = UiDevice.getInstance(instrumentation)
 
     protected fun findObjectByRes(resourceId: String): UiObject2 {


### PR DESCRIPTION
Leftover from the extract of this class from MainActivityUITest, where
everything was protected by default as a start.
