### PR TITLE
Dark mode: Slightly adjust Daily color

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -13,5 +13,5 @@
 
     <!-- Dashboard  color-->
     <color name="dash_nights">#26862e</color>
-    <color name="dash_daily">#8c6e1b</color>
+    <color name="dash_daily">#91681c</color>
 </resources>


### PR DESCRIPTION
While "Sleeps" and "Daily" have very similar [HSL](https://en.wikipedia.org/wiki/HSL_and_HSV) lightness values, "Daily" looks darker on my devices. There must be a difference in the perceived brightness of the two colors. This PR modifies the color of "Daily" to make it more visually consistent with "Sleeps".

Here is a preview. Top has the old color; bottom has the new color.

<img alt="Mockup with 'before' and 'after' color squares." src="https://github.com/user-attachments/assets/c6fe9b38-f8b4-4a9f-b7b8-a5cad9a1fedb" width="200">.

P.S.: Thanks again for the updated dark mode. It has made Plees Tracker more pleasant to use.