### PR TITLE
Export to file: add a pretty CSV mode

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     </plurals>
     <string name="settings_category_backup">Backup</string>
     <string name="settings_automatic_backup">Automatic backup</string>
+    <string name="settings_pretty_backup">Pretty backup: human-readable, but can\'t be imported</string>
     <string name="settings_compact_view">Compact view: no seconds and timezone</string>
     <string name="settings_backup_path">Backup path</string>
     <string name="widget_start_stop">Toggle tracking</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -22,6 +22,10 @@
         <Preference
             android:key="auto_backup_path"
             android:title="@string/settings_backup_path" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="pretty_backup"
+            android:title="@string/settings_pretty_backup" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_category_dashboard">

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -61,6 +61,9 @@ Backup settings allow you to automatically back up your sleeps after a tracking 
 useful in case you selected a path which is then implicitly synchronized to some external server,
 e.g. Nextcloud.
 
+Pretty backup allows you to create a CSV file which has human-readable start, stop and length values
+during exporting to a file. This pretty output can't be imported back, though.
+
 ### Dashboard
 
 You can also customize the dashboard duration, which limits the sleeps and sleep statistics on the


### PR DESCRIPTION
End-users sometimes want to show their sleep log to other people, but
the data exported to a file, but that is not human-readable.

The default export format is a CSV that is meant to be easy to import
back, i.e. a machine-readable file format.

Fix the problem by adding a setting (defaults to false): if enabled, the
export result will have formatted timestamps and also the sleep length
will be written there, if if that's redundant for a machine reader.

Fixes <https://github.com/vmiklos/plees-tracker/issues/515>.
