### PR TITLE
Export to file: include ISO date in default file name

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -40,7 +40,9 @@ import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.LibsBuilder
 import hu.vmiklos.plees_tracker.calendar.CalendarImport
 import hu.vmiklos.plees_tracker.calendar.UserCalendar
+import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.Locale
 
 /**
  * The activity is the primary UI of the app: allows starting and stopping the
@@ -294,7 +296,13 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
         intent.addCategory(Intent.CATEGORY_OPENABLE)
         intent.type = "text/csv"
-        intent.putExtra(Intent.EXTRA_TITLE, "plees-tracker.csv")
+
+        // Make it less likely that we would overwrite a previous export result.
+        val calendar = Calendar.getInstance()
+        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        val fileName = "plees-tracker-" + sdf.format(calendar.time) + ".csv"
+        intent.putExtra(Intent.EXTRA_TITLE, fileName)
+
         exportActivityResult.launch(intent)
     }
 


### PR DESCRIPTION
With the old plees-tracker.csv, the next export created 'plees-tracker
(1).csv' and so on; try to avoid annoying spaces in filenames by adding
the date to the name, so if you sleep once a day (typical), then you
don't hit this.

Fixes <https://github.com/vmiklos/plees-tracker/issues/527>.
