### PR TITLE
bedtime/wakeup: show the value of these in the preferences activity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'androidx.documentfile:documentfile:1.0.1'
+    implementation 'androidx.documentfile:documentfile:1.1.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:core:1.6.1'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
@@ -74,7 +74,7 @@ dependencies {
     implementation 'javax.annotation:jsr250-api:1.0'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.core:core-ktx:1.16.0'
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.mikepenz:aboutlibraries:7.1.0"
     implementation 'androidx.preference:preference-ktx:1.2.1'

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
@@ -11,6 +11,11 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 
 class Preferences : PreferenceFragmentCompat() {
+    private fun padMinute(raw: String): String {
+        val fro = ":([0-9])$".toRegex()
+        val to = ":0$1"
+        return raw.replace(fro, to)
+    }
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
         val autoBackupPath = findPreference<Preference>("auto_backup_path")
@@ -18,6 +23,22 @@ class Preferences : PreferenceFragmentCompat() {
             val preferences = DataModel.preferences
             val path = preferences.getString("auto_backup_path", "")
             it.summary = path
+        }
+        val wakeup = findPreference<Preference>("wakeup")
+        wakeup?.let {
+            val preferences = DataModel.preferences
+            val value = preferences.getString("wakeup", "")
+            if (value != null) {
+                it.summary = padMinute(value)
+            }
+        }
+        val bedtime = findPreference<Preference>("bedtime")
+        bedtime?.let {
+            val preferences = DataModel.preferences
+            val value = preferences.getString("bedtime", "")
+            if (value != null) {
+                it.summary = padMinute(value)
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
         <item quantity="other">Exported %d items</item>
     </plurals>
     <string name="settings_category_backup">Backup</string>
+    <string name="settings_wakeup">Wakeup</string>
+    <string name="settings_bedtime">Bedtime</string>
     <string name="settings_automatic_backup">Automatic backup</string>
     <string name="settings_pretty_backup">Pretty backup: human-readable, but can\'t be imported</string>
     <string name="settings_compact_view">Compact view: no seconds and timezone</string>
@@ -65,6 +67,7 @@
     <string name="widget_start_stop">Toggle tracking</string>
     <string name="settings_category_dashboard">Dashboard</string>
     <string name="settings_dashboard_duration">Duration</string>
+    <string name="settings_reminders">Reminders</string>
     <string name="settings_etc">Miscellaneous</string>
     <string name="settings_enable_dnd">Do not disturb when tracking</string>
     <string name="settings_enable_dnd_q_title">Permissions Required</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -85,6 +85,17 @@
     <PreferenceCategory
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:title="@string/settings_reminders">
+        <Preference
+            android:key="wakeup"
+            android:title="@string/settings_wakeup" />
+        <Preference
+            android:key="bedtime"
+            android:title="@string/settings_bedtime" />
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:title="@string/settings_etc">
         <SwitchPreference
             android:defaultValue="false"


### PR DESCRIPTION
Towards eliminating the inconsistency that these reminders can be set
via a menu item, while everything else is in the preferences activity.

This just shows the preferences so far, no modification is possible yet.
