### PR TITLE
bedtime and wakeup reminders: move UI to the preferences activity

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -6,11 +6,14 @@
 
 package hu.vmiklos.plees_tracker
 
+import android.app.TimePickerDialog
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.PreferenceManager
 
 class PreferencesActivity : AppCompatActivity() {
     companion object {
@@ -69,6 +72,47 @@ class PreferencesActivity : AppCompatActivity() {
     fun openFolderChooser() {
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
         backupActivityResult.launch(intent)
+    }
+
+    // Show a dialog to set bedtime and wakeup times (using two TimePickerDialogs sequentially)
+    fun showBedtimeDialog() {
+        val preferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+        // Get current values or use defaults (22:00 for bedtime, 07:00 for wakeup)
+        val currentBedHour = DataModel.getBedtimeHour(preferences)
+        val currentBedMinute = DataModel.getBedtimeMinute(preferences)
+        val currentWakeHour = DataModel.getWakeupHour(preferences)
+        val currentWakeMinute = DataModel.getWakeupMinute(preferences)
+
+        // First, pick bedtime
+        TimePickerDialog(
+            this,
+            { _, bedHour, bedMinute ->
+                // Save bedtime values
+                val editor = preferences.edit()
+                editor.putString("bedtime", "$bedHour:$bedMinute")
+                editor.apply()
+                // Then, pick wakeup time
+                TimePickerDialog(
+                    this,
+                    { _, wakeHour, wakeMinute ->
+                        // Save wakeup values
+                        editor.putString("wakeup", "$wakeHour:$wakeMinute")
+                        editor.apply()
+                        Toast.makeText(
+                            this,
+                            getString(R.string.bedtime_toast),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    },
+                    currentWakeHour,
+                    currentWakeMinute,
+                    true
+                ).show()
+            },
+            currentBedHour,
+            currentBedMinute,
+            true
+        ).show()
     }
 }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SharedPreferencesChangeListener.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SharedPreferencesChangeListener.kt
@@ -42,6 +42,15 @@ class SharedPreferencesChangeListener : SharedPreferences.OnSharedPreferenceChan
                 }
                 return
             }
+            "daily_reminder" -> {
+                val autoReminder = sharedPreferences.getBoolean("daily_reminder", false)
+                if (autoReminder) {
+                    val preferencesActivity = DataModel.preferencesActivity
+                    if (preferencesActivity != null) {
+                        preferencesActivity.showBedtimeDialog()
+                    }
+                }
+            }
             "enable_dnd" -> {
                 if (sharedPreferences.getBoolean("enable_dnd", false)) {
                     val preferencesActivity = DataModel.preferencesActivity

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -5,7 +5,6 @@
     <item android:id="@+id/export_file_data" android:title="@string/export_file_item"/>
     <item android:id="@+id/export_calendar_data" android:title="@string/export_calendar_item"/>
     <item android:id="@+id/stats" android:title="@string/stats" />
-    <item android:id="@+id/set_bedtime" android:title="@string/bedtime_item" />
     <item android:id="@+id/graphs" android:title="@string/graphs" />
     <item android:id="@+id/settings" android:title="@string/settings" />
     <item android:id="@+id/delete_all_sleep" android:title="@string/delete_all_sleep" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,6 @@
     <string name="deleted">Deleted</string>
     <string name="undo">Undo</string>
     <string name="about_item">About</string>
-    <string name="bedtime_item">Set Bedtime</string>
     <string name="about_toolbar">About</string>
     <string name="app_description">A simple sleep tracker for Android.</string>
     <string name="sleep_id">Sleep #%s</string>
@@ -61,6 +60,7 @@
     <string name="settings_wakeup">Wakeup</string>
     <string name="settings_bedtime">Bedtime</string>
     <string name="settings_automatic_backup">Automatic backup</string>
+    <string name="settings_daily_reminder">Daily reminder</string>
     <string name="settings_pretty_backup">Pretty backup: human-readable, but can\'t be imported</string>
     <string name="settings_compact_view">Compact view: no seconds and timezone</string>
     <string name="settings_backup_path">Backup path</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -86,6 +86,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:title="@string/settings_reminders">
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="daily_reminder"
+            android:title="@string/settings_daily_reminder" />
         <Preference
             android:key="wakeup"
             android:title="@string/settings_wakeup" />

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+- preferences: add bedtime and wakeup reminders if requested (qureshikaif)
+
 ## 25.2.1
 
 - Resolves: gh#527 export to file: include ISO date in default file name


### PR DESCRIPTION
And add a SwitchPreference to enable or disable this, which means it's
possible to disable this -- this was missing previously.
