### PR TITLE
testDelete: try to make this more robust

### DIFF
--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityUITest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/MainActivityUITest.kt
@@ -9,6 +9,7 @@ package hu.vmiklos.plees_tracker
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.uiautomator.Direction
+import androidx.test.uiautomator.StaleObjectException
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -64,8 +65,14 @@ class MainActivityUITest : UITestBase() {
         createSleep()
 
         // When deleting one:
-        val sleepSwipeable = findObjectByRes("sleep_swipeable")
-        sleepSwipeable.swipe(Direction.RIGHT, 1F)
+        while (true) {
+            try {
+                val sleepSwipeable = findObjectByRes("sleep_swipeable")
+                sleepSwipeable.swipe(Direction.RIGHT, 1F)
+                break
+            } catch (e: StaleObjectException) {
+            }
+        }
 
         // Then make sure we have no sleeps:
         assertResText("fragment_stats_sleeps", "0")


### PR DESCRIPTION
Seen this on CI:

hu.vmiklos.plees_tracker.MainActivityUITest > testDelete[emulator-5554 - 15] FAILED
	androidx.test.uiautomator.StaleObjectException
	at androidx.test.uiautomator.UiObject2.getAccessibilityNodeInfo(UiObject2.java:1018)

And when it fails locally, it points to the swipe() call, so retry that.
