### PR TITLE
CSV import: tolerate if seconds is used instead of milliseconds

### DIFF
--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -269,7 +269,7 @@ object DataModel {
     }
 
     /** Parses CSV sleeps from [reader], or returns null when the data is not a valid CSV. */
-    private suspend fun parseSleepsCsv(reader: Reader): List<Sleep>? = withContext(
+    internal suspend fun parseSleepsCsv(reader: Reader): List<Sleep>? = withContext(
         Dispatchers.IO
     ) {
         try {
@@ -284,7 +284,14 @@ object DataModel {
                 }
                 val sleep = Sleep()
                 sleep.start = cells[1].toLong()
+                // Before 2001-09? Then probably seconds was used, not milliseconds.
+                if (sleep.start < 1000000000000L) {
+                    sleep.start *= 1000
+                }
                 sleep.stop = cells[2].toLong()
+                if (sleep.stop < 1000000000000L) {
+                    sleep.stop *= 1000
+                }
                 if (cells.isSet(3)) {
                     sleep.rating = cells[3].toLong()
                 }

--- a/app/src/test/java/hu/vmiklos/plees_tracker/DataModelUnitTest.kt
+++ b/app/src/test/java/hu/vmiklos/plees_tracker/DataModelUnitTest.kt
@@ -6,9 +6,11 @@
 
 package hu.vmiklos.plees_tracker
 
+import java.io.StringReader
 import java.util.ArrayList
 import java.util.Calendar
 import java.util.Date
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -249,6 +251,19 @@ class DataModelUnitTest {
         calendar.set(2020, 2, 14, 12, 0, 0)
         val filtered = DataModel.filterSleeps(sleeps, calendar.time)
         assertEquals(filtered.size, 1)
+    }
+
+    @Test
+    fun testParseSleepsCsvSecondsToMilliseconds() = runBlocking {
+        val data = """
+sid,start,stop,rating,comment
+1,1625105400,1625121600,0,
+        """.trimIndent()
+        val reader = StringReader(data)
+        val sleeps = DataModel.parseSleepsCsv(reader)
+        assertEquals(1, sleeps?.size)
+        assertEquals(1625105400000L, sleeps?.get(0)?.start)
+        assertEquals(1625121600000L, sleeps?.get(0)?.stop)
     }
 }
 


### PR DESCRIPTION
Have a sleeps.csv produced by some external tool, try to import it into
the app, the dates are odd, way before 2001.

What happens is that the expected unit is milliseconds, but the sleep
start/stop date may be provided in seconds and there is no attempt to
recognize this.

Fix the problem by using 1,000,000,000,000 as a limit: sleep start/stop
values are typically higher than that (today is around ~1,780,000,000)
and then auto-correct from seconds to milliseconds on import.

Fixes <https://github.com/vmiklos/plees-tracker/issues/579>.
