### PR TITLE
guide: update news.md

### DIFF
--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,8 +1,11 @@
 # Changelog
 
+## master
+
+- Add optional Health Connect synchronization for sleep sessions. (Aozora7)
+
 ## 26.8
 
-- Add optional Health Connect synchronization for sleep sessions.(@aozora.one)
 - sleep activity now has a 'times woken up' widget (@Rikul)
 - backup settings redesign: multiple backup destinations (a device folder and, in the gplay flavor,
   Google Drive with restore), per-destination menus (@avi12)


### PR DESCRIPTION
The health connect code is added after the 25.8 release, but the
automatic rebase-and-merge found no conflicts and reported it as a
feature for the 25.8 release.

Add a new 'master' section and list the new feature there. Also fix up
the credit part, which so far always pointed at github handles, not
domains.
