### PR TITLE
Health connect fixes

### DIFF
--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectMigrationTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectMigrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 aozora.one
+ * Copyright 2026 Aleksandrs Serbajevs
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectMigrationTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectMigrationTest.kt
@@ -13,11 +13,9 @@ import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import java.util.UUID
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -52,7 +50,7 @@ class HealthConnectMigrationTest {
     }
 
     @Test
-    fun testMigrationCreatesIdentitiesAndTombstones() = runBlocking {
+    fun testMigrationCreatesHealthConnectStateAndTombstones() = runBlocking {
         openHelper(5) { database -> MIGRATION_4_5.migrate(database) }.close()
 
         val roomDatabase = Room.databaseBuilder(context, AppDatabase::class.java, databaseName)
@@ -61,9 +59,8 @@ class HealthConnectMigrationTest {
         try {
             val sleeps = roomDatabase.sleepDao().getAll()
             assertEquals(2, sleeps.size)
-            UUID.fromString(sleeps[0].healthConnectId)
-            UUID.fromString(sleeps[1].healthConnectId)
-            assertNotEquals(sleeps[0].healthConnectId, sleeps[1].healthConnectId)
+            assertEquals("", sleeps[0].healthConnectId)
+            assertEquals("", sleeps[1].healthConnectId)
             assertEquals(0, sleeps[0].healthConnectVersion)
             assertEquals(-1, sleeps[0].healthConnectSyncedVersion)
 

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 aozora.one
+ * Copyright 2026 Aleksandrs Serbajevs
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
@@ -7,9 +7,11 @@
 package hu.vmiklos.plees_tracker
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.os.RemoteException
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.response.InsertRecordsResponse
 import androidx.health.connect.client.response.ReadRecordsResponse
@@ -60,7 +62,7 @@ class HealthConnectSyncTest {
     }
 
     @Test
-    fun testCreateAndDelete() = runBlocking {
+    fun testCreate() = runBlocking {
         val sleep = sleep(1).apply {
             comment = "edited"
         }
@@ -70,6 +72,13 @@ class HealthConnectSyncTest {
         val records = HealthConnectBackend.readOwnRecords(client, packageName)
         assertEquals(1, records.size)
         assertEquals(HealthConnectNotes.encode(sleep), records.single().notes)
+    }
+
+    @Test
+    fun testDeleteClearsTombstone() = runBlocking {
+        val sleep = sleep(1)
+        database.sleepDao().insert(sleep)
+        HealthConnectBackend.sync(client, packageName)
 
         database.healthConnectDao().insertDeletions(
             listOf(HealthConnectDeletion(sleep.healthConnectId))
@@ -120,26 +129,15 @@ class HealthConnectSyncTest {
     }
 
     @Test
-    fun testWriteBatchesCheckpointProgress() = runBlocking {
-        database.sleepDao().insert((1..1001).map(::sleep))
-        var calls = 0
-        val secondBatchFailureClient = object : HealthConnectClient by client {
-            override suspend fun insertRecords(records: List<Record>): InsertRecordsResponse {
-                calls++
-                if (calls == 2) {
-                    throw RemoteException("rate limited")
-                }
-                return client.insertRecords(records)
-            }
-        }
-
-        try {
-            HealthConnectBackend.write(secondBatchFailureClient)
-        } catch (_: RemoteException) {
-            // The successful first chunk must stay checkpointed.
-        }
+    fun testWriteBatchesCheckpointProgressAfterFailure() = runBlocking {
+        failSecondWriteBatch()
 
         assertEquals(1, database.sleepDao().getPendingHealthConnectWrites().size)
+    }
+
+    @Test
+    fun testWriteBatchesResumeAfterFailure() = runBlocking {
+        failSecondWriteBatch()
 
         HealthConnectBackend.write(client)
 
@@ -240,46 +238,26 @@ class HealthConnectSyncTest {
     }
 
     @Test
-    fun testEnabledStateUsesBackupExcludedPreferences() {
-        val localPreferences = HealthConnectBackend.localPreferences(context)
-        val backedUpPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-        val hadLocalValue = localPreferences.contains(HealthConnectBackend.ENABLED_KEY)
-        val previousLocalValue = localPreferences.getBoolean(
-            HealthConnectBackend.ENABLED_KEY,
-            false
-        )
-        val hadBackedUpValue = backedUpPreferences.contains(HealthConnectBackend.ENABLED_KEY)
-        val previousBackedUpValue = backedUpPreferences.getBoolean(
-            HealthConnectBackend.ENABLED_KEY,
-            false
-        )
-        try {
+    fun testDisabledStateUsesBackupExcludedPreferences() {
+        withRestoredEnabledPreferences { backedUpPreferences ->
             backedUpPreferences.edit()
                 .putBoolean(HealthConnectBackend.ENABLED_KEY, true)
                 .commit()
             HealthConnectBackend.setEnabled(context, false)
-            assertFalse(HealthConnectBackend.isEnabled(context))
 
+            assertFalse(HealthConnectBackend.isEnabled(context))
+        }
+    }
+
+    @Test
+    fun testEnabledStateUsesBackupExcludedPreferences() {
+        withRestoredEnabledPreferences { backedUpPreferences ->
             backedUpPreferences.edit()
                 .putBoolean(HealthConnectBackend.ENABLED_KEY, false)
                 .commit()
             HealthConnectBackend.setEnabled(context, true)
+
             assertTrue(HealthConnectBackend.isEnabled(context))
-        } finally {
-            localPreferences.edit().apply {
-                if (hadLocalValue) {
-                    putBoolean(HealthConnectBackend.ENABLED_KEY, previousLocalValue)
-                } else {
-                    remove(HealthConnectBackend.ENABLED_KEY)
-                }
-            }.commit()
-            backedUpPreferences.edit().apply {
-                if (hadBackedUpValue) {
-                    putBoolean(HealthConnectBackend.ENABLED_KEY, previousBackedUpValue)
-                } else {
-                    remove(HealthConnectBackend.ENABLED_KEY)
-                }
-            }.commit()
         }
     }
 
@@ -359,20 +337,32 @@ class HealthConnectSyncTest {
     }
 
     @Test
-    fun testRateLimitedOperationsEventuallyComplete() = runBlocking {
+    fun testRateLimitedWriteEventuallyCompletes() = runBlocking {
         val sleep = sleep(1)
         database.sleepDao().insert(sleep)
         val rateLimitedClient = AlternatingRateLimitClient(client)
 
-        assertTrue(syncUntilSuccess(rateLimitedClient) > 1)
+        val attempts = syncUntilSuccess(rateLimitedClient)
+
+        assertTrue(attempts > 1)
         assertEquals(1, HealthConnectBackend.readOwnRecords(client, packageName).size)
+    }
+
+    @Test
+    fun testRateLimitedDeletionEventuallyCompletes() = runBlocking {
+        val sleep = sleep(1)
+        database.sleepDao().insert(sleep)
+        client.insertRecords(listOf(HealthConnectBackend.toRecord(sleep)))
 
         database.healthConnectDao().insertDeletions(
             listOf(HealthConnectDeletion(sleep.healthConnectId))
         )
         database.sleepDao().delete(sleep)
+        val rateLimitedClient = AlternatingRateLimitClient(client)
 
-        assertTrue(syncUntilSuccess(rateLimitedClient) > 1)
+        val attempts = syncUntilSuccess(rateLimitedClient)
+
+        assertTrue(attempts > 1)
         assertEquals(0, database.healthConnectDao().getDeletions().size)
     }
 
@@ -440,38 +430,15 @@ class HealthConnectSyncTest {
     }
 
     @Test
-    fun testDeletionBatchesCheckpointProgress() = runBlocking {
-        val deletions = (1..2300).map { index ->
-            HealthConnectDeletion(
-                UUID.nameUUIDFromBytes(index.toString().toByteArray()).toString()
-            )
-        }
-        database.healthConnectDao().insertDeletions(deletions)
-        val remoteByClientId = (1..2300).associate { index ->
-            val sleep = sleep(index)
-            HealthConnectBackend.CLIENT_ID_PREFIX + sleep.healthConnectId to
-                HealthConnectBackend.toRecord(sleep)
-        }
-        var calls = 0
-        val secondBatchFailureClient = object : HealthConnectClient by client {
-            override suspend fun deleteRecords(
-                recordType: KClass<out Record>,
-                recordIdsList: List<String>,
-                clientRecordIdsList: List<String>
-            ) {
-                calls++
-                if (calls == 2) {
-                    throw RemoteException("rate limited")
-                }
-            }
-        }
+    fun testDeletionBatchesCheckpointProgressAfterFailure() = runBlocking {
+        failSecondDeletionBatch()
 
-        try {
-            HealthConnectBackend.deletePending(secondBatchFailureClient, remoteByClientId)
-        } catch (_: RemoteException) {
-            // The successful first chunk must stay checkpointed.
-        }
         assertEquals(1300, database.healthConnectDao().getDeletions().size)
+    }
+
+    @Test
+    fun testDeletionBatchesResumeAfterFailure() = runBlocking {
+        val remoteByClientId = failSecondDeletionBatch()
 
         val succeedingClient = object : HealthConnectClient by client {
             override suspend fun deleteRecords(
@@ -486,7 +453,7 @@ class HealthConnectSyncTest {
     }
 
     @Test
-    fun testUnmatchedHistoricalRecordSurvivesSyncAndUnrelatedDeletion() = runBlocking {
+    fun testUnmatchedHistoricalRecordSurvivesSync() = runBlocking {
         val historical = sleep(1)
         client.insertRecords(listOf(HealthConnectBackend.toRecord(historical)))
 
@@ -501,6 +468,17 @@ class HealthConnectSyncTest {
                 .map { it.removePrefix(HealthConnectBackend.CLIENT_ID_PREFIX) }
                 .toSet()
         )
+    }
+
+    @Test
+    fun testUnmatchedHistoricalRecordSurvivesUnrelatedDeletion() = runBlocking {
+        val historical = sleep(1)
+        client.insertRecords(listOf(HealthConnectBackend.toRecord(historical)))
+
+        val current = sleep(2)
+        database.sleepDao().insert(current)
+        HealthConnectBackend.sync(client, packageName)
+        val records = HealthConnectBackend.readOwnRecords(client, packageName)
 
         database.healthConnectDao().insertDeletions(
             listOf(HealthConnectDeletion(current.healthConnectId))
@@ -592,6 +570,91 @@ class HealthConnectSyncTest {
         start = index * 3_000L
         stop = start + 1_000
         healthConnectId = UUID.nameUUIDFromBytes(index.toString().toByteArray()).toString()
+    }
+
+    private suspend fun failSecondWriteBatch() {
+        database.sleepDao().insert((1..1001).map(::sleep))
+        var calls = 0
+        val secondBatchFailureClient = object : HealthConnectClient by client {
+            override suspend fun insertRecords(records: List<Record>): InsertRecordsResponse {
+                calls++
+                if (calls == 2) {
+                    throw RemoteException("rate limited")
+                }
+                return client.insertRecords(records)
+            }
+        }
+        try {
+            HealthConnectBackend.write(secondBatchFailureClient)
+        } catch (_: RemoteException) {
+            // The successful first chunk must stay checkpointed.
+        }
+    }
+
+    private fun withRestoredEnabledPreferences(block: (SharedPreferences) -> Unit) {
+        val localPreferences = HealthConnectBackend.localPreferences(context)
+        val backedUpPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val hadLocalValue = localPreferences.contains(HealthConnectBackend.ENABLED_KEY)
+        val previousLocalValue = localPreferences.getBoolean(
+            HealthConnectBackend.ENABLED_KEY,
+            false
+        )
+        val hadBackedUpValue = backedUpPreferences.contains(HealthConnectBackend.ENABLED_KEY)
+        val previousBackedUpValue = backedUpPreferences.getBoolean(
+            HealthConnectBackend.ENABLED_KEY,
+            false
+        )
+        try {
+            block(backedUpPreferences)
+        } finally {
+            localPreferences.edit().apply {
+                if (hadLocalValue) {
+                    putBoolean(HealthConnectBackend.ENABLED_KEY, previousLocalValue)
+                } else {
+                    remove(HealthConnectBackend.ENABLED_KEY)
+                }
+            }.commit()
+            backedUpPreferences.edit().apply {
+                if (hadBackedUpValue) {
+                    putBoolean(HealthConnectBackend.ENABLED_KEY, previousBackedUpValue)
+                } else {
+                    remove(HealthConnectBackend.ENABLED_KEY)
+                }
+            }.commit()
+        }
+    }
+
+    private suspend fun failSecondDeletionBatch(): Map<String, SleepSessionRecord> {
+        val deletions = (1..2300).map { index ->
+            HealthConnectDeletion(
+                UUID.nameUUIDFromBytes(index.toString().toByteArray()).toString()
+            )
+        }
+        database.healthConnectDao().insertDeletions(deletions)
+        val remoteByClientId = (1..2300).associate { index ->
+            val sleep = sleep(index)
+            HealthConnectBackend.CLIENT_ID_PREFIX + sleep.healthConnectId to
+                HealthConnectBackend.toRecord(sleep)
+        }
+        var calls = 0
+        val secondBatchFailureClient = object : HealthConnectClient by client {
+            override suspend fun deleteRecords(
+                recordType: KClass<out Record>,
+                recordIdsList: List<String>,
+                clientRecordIdsList: List<String>
+            ) {
+                calls++
+                if (calls == 2) {
+                    throw RemoteException("rate limited")
+                }
+            }
+        }
+        try {
+            HealthConnectBackend.deletePending(secondBatchFailureClient, remoteByClientId)
+        } catch (_: RemoteException) {
+            // The successful first chunk must stay checkpointed.
+        }
+        return remoteByClientId
     }
 
     private suspend fun syncUntilSuccess(client: HealthConnectClient): Int {

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
@@ -315,7 +315,8 @@ class HealthConnectSyncTest {
 
     @Test
     fun testWipeDeletesAllOwnedRecordsInBatches() = runBlocking {
-        val records = (1..1001).map { HealthConnectBackend.toRecord(sleep(it)) }
+        val recordCount = HealthConnectBackend.HEALTH_CONNECT_BATCH_SIZE + 1
+        val records = (1..recordCount).map { HealthConnectBackend.toRecord(sleep(it)) }
         client.insertRecords(records)
         val batchSizes = mutableListOf<Int>()
         val clientRecordIdBatches = mutableListOf<List<String>>()
@@ -524,11 +525,12 @@ class HealthConnectSyncTest {
 
     @Test
     fun testBatchingAndPagination() = runBlocking {
-        database.sleepDao().insert((1..1001).map(::sleep))
+        val sleepCount = HealthConnectBackend.HEALTH_CONNECT_BATCH_SIZE + 1
+        database.sleepDao().insert((1..sleepCount).map(::sleep))
 
         HealthConnectBackend.sync(client, packageName)
 
-        assertEquals(1001, HealthConnectBackend.readOwnRecords(client, packageName).size)
+        assertEquals(sleepCount, HealthConnectBackend.readOwnRecords(client, packageName).size)
         assertEquals(0, database.sleepDao().getPendingHealthConnectWrites().size)
     }
 
@@ -573,7 +575,8 @@ class HealthConnectSyncTest {
     }
 
     private suspend fun failSecondWriteBatch() {
-        database.sleepDao().insert((1..1001).map(::sleep))
+        val sleepCount = HealthConnectBackend.HEALTH_CONNECT_BATCH_SIZE + 1
+        database.sleepDao().insert((1..sleepCount).map(::sleep))
         var calls = 0
         val secondBatchFailureClient = object : HealthConnectClient by client {
             override suspend fun insertRecords(records: List<Record>): InsertRecordsResponse {

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -95,6 +96,26 @@ class HealthConnectSyncTest {
         HealthConnectBackend.write(noReadClient)
 
         assertEquals(1, HealthConnectBackend.readOwnRecords(client, packageName).size)
+        assertEquals(0, database.sleepDao().getPendingHealthConnectWrites().size)
+    }
+
+    @Test
+    fun testWriteAssignsMissingIds() = runBlocking {
+        val first = Sleep().apply {
+            start = 1_000
+            stop = 2_000
+        }
+        val second = Sleep().apply {
+            start = 3_000
+            stop = 4_000
+        }
+        database.sleepDao().insert(listOf(first, second))
+
+        HealthConnectBackend.write(client)
+
+        val sleeps = database.sleepDao().getAll()
+        assertTrue(sleeps.all { it.healthConnectId.isNotEmpty() })
+        assertNotEquals(sleeps[0].healthConnectId, sleeps[1].healthConnectId)
         assertEquals(0, database.sleepDao().getPendingHealthConnectWrites().size)
     }
 

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
@@ -62,6 +62,53 @@ class HealthConnectSyncTest {
     }
 
     @Test
+    fun testNoForegroundWork() = runBlocking {
+        val hasWork = HealthConnectBackend.hasForegroundWork(Instant.EPOCH)
+
+        assertFalse(hasWork)
+    }
+
+    @Test
+    fun testPendingWriteRequiresForegroundWork() = runBlocking {
+        database.sleepDao().insert(sleep(1))
+
+        val hasWork = HealthConnectBackend.hasForegroundWork(Instant.EPOCH)
+
+        assertTrue(hasWork)
+    }
+
+    @Test
+    fun testInvalidPendingWriteDoesNotRequireForegroundWork() = runBlocking {
+        database.sleepDao().insert(sleep(1).apply { stop = start })
+
+        val hasWork = HealthConnectBackend.hasForegroundWork(Instant.EPOCH)
+
+        assertFalse(hasWork)
+    }
+
+    @Test
+    fun testReadableDeletionRequiresForegroundWork() = runBlocking {
+        database.healthConnectDao().insertDeletions(
+            listOf(HealthConnectDeletion(sleep(1).healthConnectId, 3_000))
+        )
+
+        val hasWork = HealthConnectBackend.hasForegroundWork(Instant.ofEpochMilli(3_000))
+
+        assertTrue(hasWork)
+    }
+
+    @Test
+    fun testUnreadableDeletionDoesNotRequireForegroundWork() = runBlocking {
+        database.healthConnectDao().insertDeletions(
+            listOf(HealthConnectDeletion(sleep(1).healthConnectId, 2_999))
+        )
+
+        val hasWork = HealthConnectBackend.hasForegroundWork(Instant.ofEpochMilli(3_000))
+
+        assertFalse(hasWork)
+    }
+
+    @Test
     fun testCreate() = runBlocking {
         val sleep = sleep(1).apply {
             comment = "edited"

--- a/app/src/foss/java/hu/vmiklos/plees_tracker/HealthConnectProviderInstaller.kt
+++ b/app/src/foss/java/hu/vmiklos/plees_tracker/HealthConnectProviderInstaller.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Aleksandrs Serbajevs
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package hu.vmiklos.plees_tracker
+
+import android.content.Intent
+
+/** Leaves Health Connect provider installation to the user in the FOSS flavor. */
+object HealthConnectProviderInstaller {
+    // Not const so shared code does not trigger constant-condition warnings.
+    val isSupported = false
+
+    fun updateIntents(): List<Intent> = emptyList()
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/app/src/gplay/java/hu/vmiklos/plees_tracker/HealthConnectProviderInstaller.kt
+++ b/app/src/gplay/java/hu/vmiklos/plees_tracker/HealthConnectProviderInstaller.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Aleksandrs Serbajevs
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package hu.vmiklos.plees_tracker
+
+import android.content.Intent
+import androidx.core.net.toUri
+
+/** Opens Google Play to install or update the Health Connect provider. */
+object HealthConnectProviderInstaller {
+    private const val PROVIDER_PACKAGE_NAME = "com.google.android.apps.healthdata"
+    private const val PLAY_STORE_PACKAGE_NAME = "com.android.vending"
+    private const val PLAY_STORE_URL =
+        "https://play.google.com/store/apps/details?id=$PROVIDER_PACKAGE_NAME"
+
+    // Not const so shared code does not trigger constant-condition warnings.
+    val isSupported = true
+
+    fun updateIntents(): List<Intent> = listOf(
+        Intent(Intent.ACTION_VIEW).apply {
+            data = "market://details?id=$PROVIDER_PACKAGE_NAME".toUri()
+            setPackage(PLAY_STORE_PACKAGE_NAME)
+        },
+        Intent(Intent.ACTION_VIEW, PLAY_STORE_URL.toUri())
+    )
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -72,19 +72,13 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
             "ALTER TABLE sleep ADD COLUMN health_connect_id TEXT NOT NULL DEFAULT ''"
         )
         db.execSQL(
-            "UPDATE sleep SET health_connect_id = " +
-                "lower(hex(randomblob(4))) || '-' || lower(hex(randomblob(2))) || '-' || " +
-                "lower(hex(randomblob(2))) || '-' || lower(hex(randomblob(2))) || '-' || " +
-                "lower(hex(randomblob(6)))"
-        )
-        db.execSQL(
             "ALTER TABLE sleep ADD COLUMN health_connect_version INTEGER NOT NULL DEFAULT 0"
         )
         db.execSQL(
             "ALTER TABLE sleep ADD COLUMN health_connect_synced_version INTEGER NOT NULL DEFAULT -1"
         )
         db.execSQL(
-            "CREATE UNIQUE INDEX index_Sleep_health_connect_id ON sleep(health_connect_id)"
+            "CREATE INDEX index_Sleep_health_connect_id ON sleep(health_connect_id)"
         )
         db.execSQL(
             "CREATE TABLE IF NOT EXISTS health_connect_deletion (" +
@@ -244,7 +238,9 @@ object DataModel {
 
     suspend fun insertSleep(sleep: Sleep) {
         database.withTransaction {
-            database.healthConnectDao().deleteDeletions(listOf(sleep.healthConnectId))
+            if (sleep.healthConnectId.isNotEmpty()) {
+                database.healthConnectDao().deleteDeletions(listOf(sleep.healthConnectId))
+            }
             database.sleepDao().insert(sleep)
         }
         scheduleHealthConnectSync()
@@ -256,7 +252,7 @@ object DataModel {
         }
         database.withTransaction {
             database.healthConnectDao().deleteDeletionsBatched(
-                sleepList.map { it.healthConnectId }
+                sleepList.map { it.healthConnectId }.filter { it.isNotEmpty() }
             )
             database.sleepDao().insert(sleepList)
         }
@@ -270,7 +266,9 @@ object DataModel {
 
     suspend fun deleteSleep(sleep: Sleep) {
         database.withTransaction {
-            database.healthConnectDao().insertDeletions(listOf(deletionFor(sleep)))
+            if (sleep.healthConnectId.isNotEmpty()) {
+                database.healthConnectDao().insertDeletions(listOf(deletionFor(sleep)))
+            }
             database.sleepDao().delete(sleep)
         }
         scheduleHealthConnectSync()
@@ -279,7 +277,9 @@ object DataModel {
     suspend fun deleteAllSleep() {
         database.withTransaction {
             val sleeps = database.sleepDao().getAll()
-            database.healthConnectDao().insertDeletions(sleeps.map(::deletionFor))
+            database.healthConnectDao().insertDeletions(
+                sleeps.filter { it.healthConnectId.isNotEmpty() }.map(::deletionFor)
+            )
             database.sleepDao().deleteAll()
         }
         scheduleHealthConnectSync()
@@ -374,7 +374,7 @@ object DataModel {
                         UUID.fromString(id)
                         sleep.healthConnectId = id
                     } catch (_: IllegalArgumentException) {
-                        // Keep the freshly-generated ID for invalid or legacy values.
+                        // Keep the empty ID for invalid or legacy values.
                     }
                 }
                 if (cells.isSet(7)) {
@@ -397,10 +397,12 @@ object DataModel {
      */
     private suspend fun insertNewSleeps(importedSleeps: List<Sleep>) {
         val oldSleeps = database.sleepDao().getAll()
-        val usedIds = oldSleeps.mapTo(mutableSetOf()) { it.healthConnectId }
+        val usedIds = oldSleeps.mapNotNullTo(mutableSetOf()) {
+            it.healthConnectId.ifEmpty { null }
+        }
         val newSleeps = importedSleeps.subtract(oldSleeps.toSet()).onEach { sleep ->
-            while (!usedIds.add(sleep.healthConnectId)) {
-                sleep.healthConnectId = UUID.randomUUID().toString()
+            if (sleep.healthConnectId.isNotEmpty() && !usedIds.add(sleep.healthConnectId)) {
+                sleep.healthConnectId = ""
                 sleep.healthConnectVersion = 0
             }
         }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 aozora.one
+ * Copyright 2026 Aleksandrs Serbajevs
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
@@ -226,14 +226,25 @@ object HealthConnectBackend {
     }
 
     @RequiresApi(Build.VERSION_CODES.P)
-    suspend fun reconcileForeground(context: Context) {
+    suspend fun reconcileForeground(context: Context, force: Boolean = false) {
         if (!isEnabled(context)) {
+            return
+        }
+        val readablePeriodStart = readablePeriodStart(context)
+        if (!force && !hasForegroundWork(readablePeriodStart)) {
             return
         }
         val client = HealthConnectClient.getOrCreate(context)
         operationMutex.withLock {
-            sync(client, context.packageName, readablePeriodStart(context))
+            sync(client, context.packageName, readablePeriodStart)
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    internal suspend fun hasForegroundWork(readablePeriodStart: Instant): Boolean {
+        val after = readablePeriodStart.toEpochMilli()
+        return DataModel.database.sleepDao().hasPendingHealthConnectWrites(after) ||
+            DataModel.database.healthConnectDao().hasDeletions(after)
     }
 
     /** Deletes every sleep record whose Health Connect data origin is this app. */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
@@ -42,8 +42,8 @@ object HealthConnectBackend {
     internal const val CLIENT_ID_PREFIX = "plees-sleep:"
     internal const val LOCAL_PREFERENCES_NAME = "health_connect_local"
     internal const val READ_CUTOFF_KEY = "health_connect_read_cutoff"
+    internal const val HEALTH_CONNECT_BATCH_SIZE = 1000
     private const val WORK_NAME = "health_connect_sync"
-    private const val PAGE_SIZE = 1000
     private const val LEGACY_READ_MILLIS = 30L * 24 * 60 * 60 * 1000
     private const val TAG = "HealthConnectBackend"
     private val operationMutex = Mutex()
@@ -251,7 +251,7 @@ object HealthConnectBackend {
     @RequiresApi(Build.VERSION_CODES.P)
     internal suspend fun wipe(client: HealthConnectClient, packageName: String) {
         val ownRecords = readOwnRecords(client, packageName)
-        for (chunk in ownRecords.chunked(PAGE_SIZE)) {
+        for (chunk in ownRecords.chunked(HEALTH_CONNECT_BATCH_SIZE)) {
             client.deleteRecords(
                 SleepSessionRecord::class,
                 recordIdsList = chunk.map { it.metadata.id },
@@ -350,7 +350,7 @@ object HealthConnectBackend {
             sleep.healthConnectId = UUID.randomUUID().toString()
             healthDao.assignId(sleep.sid, sleep.healthConnectId)
         }
-        for (chunk in sleeps.chunked(PAGE_SIZE)) {
+        for (chunk in sleeps.chunked(HEALTH_CONNECT_BATCH_SIZE)) {
             client.insertRecords(chunk.map(::toRecord))
             // Persist progress after every successful provider batch. The version predicate in
             // markVersionSynced prevents a concurrent edit from being marked as uploaded.
@@ -395,7 +395,7 @@ object HealthConnectBackend {
                 deletion.start >= readablePeriodStart.toEpochMilli()
             }
             .map { it.healthConnectId }
-        for (chunk in tombstoneIds.chunked(PAGE_SIZE)) {
+        for (chunk in tombstoneIds.chunked(HEALTH_CONNECT_BATCH_SIZE)) {
             val clientIds = chunk.map { CLIENT_ID_PREFIX + it }
             val recordIds = clientIds.mapNotNull { remoteByClientId[it]?.metadata?.id }
             if (recordIds.isNotEmpty()) {
@@ -433,7 +433,7 @@ object HealthConnectBackend {
                 ReadRecordsRequest<SleepSessionRecord>(
                     timeRangeFilter = TimeRangeFilter.after(readablePeriodStart),
                     dataOriginFilter = setOf(DataOrigin(packageName)),
-                    pageSize = PAGE_SIZE,
+                    pageSize = HEALTH_CONNECT_BATCH_SIZE,
                     pageToken = pageToken
                 )
             )

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
@@ -346,13 +346,17 @@ object HealthConnectBackend {
 
     @RequiresApi(Build.VERSION_CODES.P)
     internal suspend fun write(client: HealthConnectClient) {
-        val pending = DataModel.database.sleepDao().getPendingHealthConnectWrites()
-        write(client, validSleeps(pending))
+        val pending = validSleeps(DataModel.database.sleepDao().getPendingHealthConnectWrites())
+        write(client, pending)
     }
 
     @RequiresApi(Build.VERSION_CODES.P)
     private suspend fun write(client: HealthConnectClient, sleeps: List<Sleep>) {
         val healthDao = DataModel.database.healthConnectDao()
+        for (sleep in sleeps.filter { it.healthConnectId.isEmpty() }) {
+            sleep.healthConnectId = UUID.randomUUID().toString()
+            healthDao.assignId(sleep.sid, sleep.healthConnectId)
+        }
         for (chunk in sleeps.chunked(PAGE_SIZE)) {
             client.insertRecords(chunk.map(::toRecord))
             // Persist progress after every successful provider batch. The version predicate in

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
@@ -14,7 +14,6 @@ import android.os.Build
 import android.util.Log
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.RequiresApi
-import androidx.core.net.toUri
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.HealthConnectFeatures
 import androidx.health.connect.client.PermissionController
@@ -43,7 +42,6 @@ object HealthConnectBackend {
     internal const val CLIENT_ID_PREFIX = "plees-sleep:"
     internal const val LOCAL_PREFERENCES_NAME = "health_connect_local"
     internal const val READ_CUTOFF_KEY = "health_connect_read_cutoff"
-    private const val PROVIDER_PACKAGE_NAME = "com.google.android.apps.healthdata"
     private const val WORK_NAME = "health_connect_sync"
     private const val PAGE_SIZE = 1000
     private const val LEGACY_READ_MILLIS = 30L * 24 * 60 * 60 * 1000
@@ -96,11 +94,6 @@ object HealthConnectBackend {
 
     fun cancelSync(context: Context) {
         WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
-    }
-
-    fun providerUpdateIntent(): Intent = Intent(Intent.ACTION_VIEW).apply {
-        data = "market://details?id=$PROVIDER_PACKAGE_NAME".toUri()
-        setPackage("com.android.vending")
     }
 
     fun permissionSettingsIntent(context: Context): Intent {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectDao.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectDao.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 aozora.one
+ * Copyright 2026 Aleksandrs Serbajevs
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectDao.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectDao.kt
@@ -29,6 +29,9 @@ interface HealthConnectDao {
         }
     }
 
+    @Query("UPDATE sleep SET health_connect_id = :id WHERE sid = :sid AND health_connect_id = ''")
+    suspend fun assignId(sid: Int, id: String)
+
     @Query(
         "UPDATE sleep SET health_connect_version = :version " +
             "WHERE health_connect_id = :id AND health_connect_version = :expectedVersion"

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectDao.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectDao.kt
@@ -17,6 +17,9 @@ interface HealthConnectDao {
     @Query("SELECT * FROM health_connect_deletion")
     suspend fun getDeletions(): List<HealthConnectDeletion>
 
+    @Query("SELECT EXISTS(SELECT 1 FROM health_connect_deletion WHERE start_date >= :after)")
+    suspend fun hasDeletions(after: Long): Boolean
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertDeletions(deletions: List<HealthConnectDeletion>)
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectDeletion.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectDeletion.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 aozora.one
+ * Copyright 2026 Aleksandrs Serbajevs
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectNotes.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectNotes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 aozora.one
+ * Copyright 2026 Aleksandrs Serbajevs
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectRationaleActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectRationaleActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 aozora.one
+ * Copyright 2026 Aleksandrs Serbajevs
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectWorker.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectWorker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 aozora.one
+ * Copyright 2026 Aleksandrs Serbajevs
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
@@ -158,9 +158,15 @@ class Preferences : PreferenceFragmentCompat() {
             }
             HealthConnectBackend.Availability.UPDATE_REQUIRED -> {
                 HealthConnectBackend.setEnabled(requireContext(), false)
-                preference.isEnabled = true
+                preference.isEnabled = HealthConnectProviderInstaller.isSupported
                 preference.isChecked = false
-                preference.setSummary(R.string.settings_health_connect_update)
+                preference.setSummary(
+                    if (HealthConnectProviderInstaller.isSupported) {
+                        R.string.settings_health_connect_update
+                    } else {
+                        R.string.settings_health_connect_update_manually
+                    }
+                )
             }
             HealthConnectBackend.Availability.AVAILABLE -> {
                 preference.isEnabled = true

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Preferences.kt
@@ -127,6 +127,18 @@ class Preferences : PreferenceFragmentCompat() {
             isVisible = false
             category.addPreference(this)
         }
+        Preference(requireContext()).apply {
+            key = PreferencesActivity.HEALTH_CONNECT_FORCE_SYNC_KEY
+            order = 2
+            setTitle(R.string.settings_health_connect_force_sync)
+            setSummary(R.string.settings_health_connect_force_sync_summary)
+            isVisible = false
+            setOnPreferenceClickListener {
+                (activity as? PreferencesActivity)?.forceHealthConnectSync()
+                true
+            }
+            category.addPreference(this)
+        }
     }
 
     private fun refreshHealthConnectState() {
@@ -137,6 +149,10 @@ class Preferences : PreferenceFragmentCompat() {
         val checking = (activity as? PreferencesActivity)?.healthConnectCheckPending == true
         findPreference<Preference>(PreferencesActivity.HEALTH_CONNECT_CHECK_ACTIONS_KEY)
             ?.isVisible = checking
+        val forceSyncPreference = findPreference<Preference>(
+            PreferencesActivity.HEALTH_CONNECT_FORCE_SYNC_KEY
+        )
+        forceSyncPreference?.isVisible = false
         if (checking) {
             // Reflect the attempted opt-in without enabling synchronization until the check or
             // an explicit skip completes.
@@ -194,6 +210,7 @@ class Preferences : PreferenceFragmentCompat() {
                                     R.string.settings_health_connect_off
                                 }
                             )
+                            forceSyncPreference?.isVisible = stored
                             return@launch
                         }
                     }
@@ -202,6 +219,7 @@ class Preferences : PreferenceFragmentCompat() {
                         HealthConnectBackend.cancelSync(requireContext())
                     }
                     preference.isChecked = stored && granted
+                    forceSyncPreference?.isVisible = preference.isChecked
                     preference.setSummary(
                         if (preference.isChecked) {
                             R.string.settings_health_connect_on

--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -367,11 +367,17 @@ class PreferencesActivity : AppCompatActivity() {
             return
         }
         healthConnectImportDialogShowing = true
+        val canReadAllHistory = HealthConnectBackend.canReadAllHistory(applicationContext)
+        val message = if (canReadAllHistory) {
+            R.plurals.health_connect_import_message_all_history
+        } else {
+            R.plurals.health_connect_import_message
+        }
         val builder = AlertDialog.Builder(this)
             .setTitle(R.string.health_connect_import_title)
             .setMessage(
                 resources.getQuantityString(
-                    R.plurals.health_connect_import_message,
+                    message,
                     sleeps.size,
                     sleeps.size
                 )
@@ -386,7 +392,7 @@ class PreferencesActivity : AppCompatActivity() {
                 finishHealthConnectEnable()
             }
             .setCancelable(false)
-        if (HealthConnectBackend.canReadAllHistory(applicationContext)) {
+        if (canReadAllHistory) {
             builder.setNeutralButton(R.string.health_connect_wipe, null)
         }
         val dialog = builder.create()
@@ -394,7 +400,7 @@ class PreferencesActivity : AppCompatActivity() {
             healthConnectImportDialogShowing = false
         }
         dialog.setOnShowListener {
-            if (!HealthConnectBackend.canReadAllHistory(applicationContext)) {
+            if (!canReadAllHistory) {
                 return@setOnShowListener
             }
             val importButton = dialog.getButton(DialogInterface.BUTTON_POSITIVE)

--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -20,7 +20,6 @@ import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
-import androidx.core.net.toUri
 import androidx.health.connect.client.HealthConnectClient
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -48,9 +47,6 @@ class PreferencesActivity : AppCompatActivity() {
         private const val HEALTH_CONNECT_READ_TIMEOUT_MS = 30_000L
         private const val HEALTH_CONNECT_RETRY_INITIAL_DELAY_MS = 1_000L
         private const val HEALTH_CONNECT_RETRY_MAX_DELAY_MS = 30_000L
-        private const val HEALTH_CONNECT_APP_URL =
-            "https://play.google.com/store/apps/details?id=com.google.android.apps.healthdata"
-
         internal const val HEALTH_CONNECT_CHECK_ACTIONS_KEY = "health_connect_check_actions"
     }
 
@@ -207,13 +203,13 @@ class PreferencesActivity : AppCompatActivity() {
         }
 
     fun openHealthConnectProvider() {
-        try {
-            startActivity(HealthConnectBackend.providerUpdateIntent())
-        } catch (e: Exception) {
-            Log.e(TAG, "openHealthConnectProvider: $e")
-            startActivity(
-                Intent(Intent.ACTION_VIEW, (HEALTH_CONNECT_APP_URL).toUri())
-            )
+        for (intent in HealthConnectProviderInstaller.updateIntents()) {
+            try {
+                startActivity(intent)
+                return
+            } catch (e: Exception) {
+                Log.e(TAG, "openHealthConnectProvider: $e")
+            }
         }
     }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -48,6 +48,7 @@ class PreferencesActivity : AppCompatActivity() {
         private const val HEALTH_CONNECT_RETRY_INITIAL_DELAY_MS = 1_000L
         private const val HEALTH_CONNECT_RETRY_MAX_DELAY_MS = 30_000L
         internal const val HEALTH_CONNECT_CHECK_ACTIONS_KEY = "health_connect_check_actions"
+        internal const val HEALTH_CONNECT_FORCE_SYNC_KEY = "health_connect_force_sync"
     }
 
     // Pending state of an in-flight folder-picker or Drive sign-in flow. The system activities
@@ -447,6 +448,7 @@ class PreferencesActivity : AppCompatActivity() {
             putBoolean(HealthConnectBackend.ENABLED_KEY, true)
             putBoolean(HealthConnectBackend.INITIALIZED_KEY, true)
         }
+        forceHealthConnectSync(showResult = false)
         lifecycleScope.launch {
             if (DataModel.hasSleeps() ||
                 DataModel.database.healthConnectDao().getDeletions().isNotEmpty()
@@ -455,6 +457,29 @@ class PreferencesActivity : AppCompatActivity() {
             }
         }
         refreshFragment()
+    }
+
+    fun forceHealthConnectSync() {
+        forceHealthConnectSync(showResult = true)
+    }
+
+    private fun forceHealthConnectSync(showResult: Boolean) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            return
+        }
+        lifecycleScope.launch {
+            try {
+                HealthConnectBackend.reconcileForeground(applicationContext, force = true)
+                if (showResult) {
+                    toast(R.string.health_connect_force_sync_finished)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "forceHealthConnectSync: $e")
+                if (showResult) {
+                    toast(R.string.health_connect_temporarily_unavailable)
+                }
+            }
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Sleep.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Sleep.kt
@@ -11,12 +11,11 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import java.util.UUID
 
 /**
  * Represents one tracked sleep.
  */
-@Entity(indices = [Index(value = ["health_connect_id"], unique = true)])
+@Entity(indices = [Index(value = ["health_connect_id"])])
 class Sleep {
     @PrimaryKey(autoGenerate = true)
     var sid: Int = 0
@@ -38,7 +37,7 @@ class Sleep {
 
     // Identifies the record across devices, where sid values can collide.
     @ColumnInfo(name = "health_connect_id")
-    var healthConnectId: String = UUID.randomUUID().toString()
+    var healthConnectId: String = ""
 
     // Incremented on edits and sent to Health Connect to order updates.
     @ColumnInfo(name = "health_connect_version")

--- a/app/src/main/java/hu/vmiklos/plees_tracker/Sleep.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/Sleep.kt
@@ -36,12 +36,15 @@ class Sleep {
     @ColumnInfo(name = "wakes")
     var wakes: Int = 0
 
+    // Identifies the record across devices, where sid values can collide.
     @ColumnInfo(name = "health_connect_id")
     var healthConnectId: String = UUID.randomUUID().toString()
 
+    // Incremented on edits and sent to Health Connect to order updates.
     @ColumnInfo(name = "health_connect_version")
     var healthConnectVersion: Long = 0
 
+    // Stores the last uploaded healthConnectVersion; unequal values mean a write is pending.
     @ColumnInfo(name = "health_connect_synced_version")
     var healthConnectSyncedVersion: Long = -1
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepDao.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepDao.kt
@@ -28,6 +28,13 @@ interface SleepDao {
     )
     suspend fun getPendingHealthConnectWrites(): List<Sleep>
 
+    @Query(
+        "SELECT EXISTS(SELECT 1 FROM sleep " +
+            "WHERE health_connect_synced_version != health_connect_version " +
+            "AND stop_date > start_date AND start_date >= :after)"
+    )
+    suspend fun hasPendingHealthConnectWrites(after: Long): Boolean
+
     @Query("SELECT * FROM sleep ORDER BY start_date DESC")
     fun getAllLive(): LiveData<List<Sleep>>
 

--- a/app/src/main/res/values-v34/strings.xml
+++ b/app/src/main/res/values-v34/strings.xml
@@ -1,6 +1,0 @@
-<resources>
-    <plurals name="health_connect_import_message">
-        <item quantity="one">Health Connect contains %d sleep previously written by Plees Tracker that are not in this installation. You can import it to this installation, ignore it, or wipe health connect before synchronizing.</item>
-        <item quantity="other">Health Connect contains %d sleeps previously written by Plees Tracker that are not in this installation. You can import them to this installation, ignore them, or wipe health connect before synchronizing. </item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,9 @@
     <string name="settings_health_connect_unavailable">Requires Android 9 or newer and Health Connect</string>
     <string name="settings_health_connect_update">Install or update Health Connect to enable</string>
     <string name="settings_health_connect_update_manually">Install or update Health Connect separately to enable</string>
+    <string name="settings_health_connect_force_sync">Force sync</string>
+    <string name="settings_health_connect_force_sync_summary">Add, update, or delete Health Connect sleep records to match Plees Tracker</string>
+    <string name="health_connect_force_sync_finished">Health Connect sync finished</string>
     <string name="health_connect_permission_denied_title">Health Connect permission required</string>
     <string name="health_connect_permission_denied_message">Sleep access was not granted. Allow Plees Tracker to write sleep data in Health Connect settings to enable synchronization.</string>
     <string name="health_connect_temporarily_unavailable">Health Connect is temporarily unavailable. Try again later.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="settings_health_connect_checking">Checking for existing Health Connect records</string>
     <string name="settings_health_connect_unavailable">Requires Android 9 or newer and Health Connect</string>
     <string name="settings_health_connect_update">Install or update Health Connect to enable</string>
+    <string name="settings_health_connect_update_manually">Install or update Health Connect separately to enable</string>
     <string name="health_connect_permission_denied_title">Health Connect permission required</string>
     <string name="health_connect_permission_denied_message">Sleep access was not granted. Allow Plees Tracker to write sleep data in Health Connect settings to enable synchronization.</string>
     <string name="health_connect_temporarily_unavailable">Health Connect is temporarily unavailable. Try again later.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,10 @@
         <item quantity="one">Health Connect contains %d sleep previously written by Plees Tracker that is not in this installation. You can import it or keep it only in Health Connect. When the installed Health Connect version cannot expose Plees Tracker’s complete history, access begins 30 days before permission was granted; older sleeps cannot be imported or reconciled.</item>
         <item quantity="other">Health Connect contains %d sleeps previously written by Plees Tracker that are not in this installation. You can import them or keep them only in Health Connect. When the installed Health Connect version cannot expose Plees Tracker’s complete history, access begins 30 days before permission was granted; older sleeps cannot be imported or reconciled.</item>
     </plurals>
+    <plurals name="health_connect_import_message_all_history">
+        <item quantity="one">Health Connect contains %d sleep previously written by Plees Tracker that is not in this installation. You can import it to this installation, ignore it, or wipe Health Connect before synchronizing.</item>
+        <item quantity="other">Health Connect contains %d sleeps previously written by Plees Tracker that are not in this installation. You can import them to this installation, ignore them, or wipe Health Connect before synchronizing.</item>
+    </plurals>
     <string name="health_connect_import">Import</string>
     <string name="health_connect_skip">Skip</string>
     <string name="health_connect_skip_check">Skip check</string>

--- a/app/src/test/java/hu/vmiklos/plees_tracker/DataModelUnitTest.kt
+++ b/app/src/test/java/hu/vmiklos/plees_tracker/DataModelUnitTest.kt
@@ -20,12 +20,12 @@ import org.junit.Test
  */
 class DataModelUnitTest {
     @Test
-    fun testParseLegacySleepCsvGeneratesHealthConnectIdentity() = runBlocking {
+    fun testParseLegacySleepCsvLeavesHealthConnectIdentityEmpty() = runBlocking {
         val csv = "sid,start,stop,rating,comment,wakes\n0,10000,20000,3,hi,2\n"
 
         val sleep = DataModel.parseSleepsCsv(StringReader(csv))?.single() ?: Sleep()
 
-        assertTrue(sleep.healthConnectId.isNotEmpty())
+        assertTrue(sleep.healthConnectId.isEmpty())
         assertEquals(0L, sleep.healthConnectVersion)
     }
 

--- a/app/src/test/java/hu/vmiklos/plees_tracker/HealthConnectBackendUnitTest.kt
+++ b/app/src/test/java/hu/vmiklos/plees_tracker/HealthConnectBackendUnitTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 aozora.one
+ * Copyright 2026 Aleksandrs Serbajevs
  *
  * SPDX-License-Identifier: MIT
  */

--- a/app/src/test/java/hu/vmiklos/plees_tracker/HealthConnectNotesUnitTest.kt
+++ b/app/src/test/java/hu/vmiklos/plees_tracker/HealthConnectNotesUnitTest.kt
@@ -26,6 +26,22 @@ class HealthConnectNotesUnitTest {
     }
 
     @Test
+    fun testEmptyMetadataRoundTrip() {
+        val decoded = HealthConnectNotes.decode(
+            HealthConnectNotes.encode(sleep(comment = "", rating = 0, wakes = 0))
+        )
+
+        assertEquals(HealthConnectNotes.Values("", 0, 0), decoded)
+    }
+
+    @Test
+    fun testNullNotesDecodeAsEmptyMetadata() {
+        val decoded = HealthConnectNotes.decode(null)
+
+        assertEquals(HealthConnectNotes.Values("", 0, 0), decoded)
+    }
+
+    @Test
     fun testOneSpecifiedMetadataValueWritesFooter() {
         assertEquals(
             "Plees Tracker metadata v1\nRating: 4\nWakes: 0",

--- a/app/src/test/java/hu/vmiklos/plees_tracker/HealthConnectNotesUnitTest.kt
+++ b/app/src/test/java/hu/vmiklos/plees_tracker/HealthConnectNotesUnitTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 aozora.one
+ * Copyright 2026 Aleksandrs Serbajevs
  *
  * SPDX-License-Identifier: MIT
  */


### PR DESCRIPTION
Based on feedback in #586

* Removed the intent to open Play Store to install Health Connect from the foss flavor. gplay flavor will open Play Store, while foss flavor will disable the button and show text prompting the user to install the provider manually. This only affects devices with Android 9-13, since from 14 onwards Health Connect is a part of the system. Tell me if this doesn't alleviate your concern and I will move the entire health connect feature to gplay only as a part of this PR. 
* Moved Health Connect UUID assignment from sleep object initialization to Health Connect write. This change includes not writing deletions when there is no health connect ID in the record. This required removing unique from the index, I added the change to the existing migration since this has not been released yet. 
* Adjusted reconcileForeground to return early if there are no writes or deletions pending. There can still be edge cases where the user might want to run the full sync without pending writes, added a separate settings button for that specifically. 
* Removed the version-specific strings file
* Split test cases to avoid execution after assertions. 
* Checked empty metadata round-trip on device. Work correctly. Added tests for null and empty string. 
* Updated copyright notices to use my real name, it's public anyway. 
* Added comments to health connect database fields to explain their purpose/necessity.

> health_connect_version is exported to CSV, do you want to export health_connect_synced_version to CSV as well?

health_connect_synced_version is not exported to CSV since it would provide no useful information when imported. If the app exported a CSV with a sleep record that still had a pending update for health connect on the current device, it would still export the newest version, and so the importing app would also get the newest version and write that version to health connect if enabled. 

I attempted to address everything actionable. Please remind me if I missed anything. 