### PR TITLE
Health Connect backend WorkManager implementation

### DIFF
--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
@@ -110,6 +110,32 @@ class HealthConnectSyncTest {
     }
 
     @Test
+    fun testDeleteUsesCurrentDatabaseHealthConnectId() = runBlocking {
+        database.sleepDao().insert(sleep(1).apply { healthConnectId = "" })
+        val staleSleep = database.sleepDao().getAll().single()
+        val assignedId = UUID.randomUUID().toString()
+        database.healthConnectDao().assignId(staleSleep.sid, assignedId)
+
+        DataModel.deleteSleepFromDatabase(staleSleep)
+
+        assertEquals(
+            listOf(HealthConnectDeletion(assignedId, staleSleep.start)),
+            database.healthConnectDao().getDeletions()
+        )
+    }
+
+    @Test
+    fun testDeletedSleepIsNotWrittenAfterIdAssignmentFails() = runBlocking {
+        database.sleepDao().insert(sleep(1).apply { healthConnectId = "" })
+        val pending = database.sleepDao().getPendingHealthConnectWrites()
+        database.sleepDao().delete(pending.single())
+
+        HealthConnectBackend.write(client, pending)
+
+        assertEquals(0, HealthConnectBackend.readOwnRecords(client, packageName).size)
+    }
+
+    @Test
     fun testCreate() = runBlocking {
         val sleep = sleep(1).apply {
             comment = "edited"

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectSyncTest.kt
@@ -26,6 +26,7 @@ import java.time.Clock
 import java.time.Instant
 import java.util.UUID
 import kotlin.reflect.KClass
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -189,6 +190,80 @@ class HealthConnectSyncTest {
         HealthConnectBackend.write(client)
 
         assertEquals(0, database.sleepDao().getPendingHealthConnectWrites().size)
+    }
+
+    @Test
+    fun testForceReconcileRepairsCancelledWrite() = runBlocking {
+        val sleepCount = HealthConnectBackend.HEALTH_CONNECT_BATCH_SIZE + 1
+        database.sleepDao().insert((1..sleepCount).map(::sleep))
+        var calls = 0
+        val cancelledClient = object : HealthConnectClient by client {
+            override suspend fun insertRecords(records: List<Record>): InsertRecordsResponse {
+                calls++
+                if (calls == 2) {
+                    throw CancellationException("replaced by force reconciliation")
+                }
+                return client.insertRecords(records)
+            }
+        }
+        try {
+            HealthConnectBackend.write(cancelledClient)
+        } catch (_: CancellationException) {
+            // WorkManager REPLACE can cancel an automatic write after a completed batch.
+        }
+
+        HealthConnectBackend.sync(client, packageName)
+
+        assertEquals(
+            Pair(sleepCount, 0),
+            Pair(
+                HealthConnectBackend.readOwnRecords(client, packageName).size,
+                database.sleepDao().getPendingHealthConnectWrites().size
+            )
+        )
+    }
+
+    @Test
+    fun testRapidWritesAndForceReconciliationsConverge() = runBlocking {
+        repeat(12) { round ->
+            val firstIndex = round * 4 + 1
+            database.sleepDao().insert((firstIndex until firstIndex + 4).map(::sleep))
+            database.sleepDao().getAll().forEachIndexed { index, stored ->
+                if (index % 3 == round % 3) {
+                    stored.comment = "round $round, sleep $index"
+                    stored.healthConnectVersion++
+                    database.sleepDao().update(stored)
+                }
+            }
+            if (round % 3 == 2) {
+                HealthConnectBackend.sync(client, packageName)
+            } else {
+                HealthConnectBackend.write(client)
+            }
+        }
+        repeat(3) {
+            HealthConnectBackend.sync(client, packageName)
+        }
+
+        val local = database.sleepDao().getAll()
+        val expected = local.map { stored ->
+            Triple(
+                HealthConnectBackend.CLIENT_ID_PREFIX + stored.healthConnectId,
+                stored.healthConnectVersion,
+                HealthConnectNotes.encode(stored)
+            )
+        }.sortedBy { it.first }
+        val actual = HealthConnectBackend.readOwnRecords(client, packageName).map { record ->
+            Triple(
+                record.metadata.clientRecordId,
+                record.metadata.clientRecordVersion,
+                record.notes
+            )
+        }.sortedBy { it.first }
+        assertEquals(
+            Pair(expected, 0),
+            Pair(actual, database.sleepDao().getPendingHealthConnectWrites().size)
+        )
     }
 
     @Test

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectWorkTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectWorkTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Aleksandrs Serbajevs
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package hu.vmiklos.plees_tracker
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** On-device tests for the WorkManager result bridge used by Health Connect operations. */
+@RunWith(AndroidJUnit4::class)
+class HealthConnectWorkTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun testSuccessfulWorkResultIsReported() = runBlocking {
+        val preferences = HealthConnectBackend.localPreferences(context)
+        val hadEnabled = preferences.contains(HealthConnectBackend.ENABLED_KEY)
+        val wasEnabled = HealthConnectBackend.isEnabled(context)
+        HealthConnectBackend.setEnabled(context, false)
+        val request = OneTimeWorkRequestBuilder<HealthConnectWorker>()
+            .setInputData(
+                workDataOf(
+                    HealthConnectBackend.OPERATION_KEY to
+                        HealthConnectBackend.Operation.WRITE.name,
+                    HealthConnectBackend.USER_INITIATED_KEY to true
+                )
+            )
+            .build()
+        val succeeded = try {
+            WorkManager.getInstance(context).enqueue(request)
+            HealthConnectBackend.awaitSuccess(context, request.id)
+        } finally {
+            preferences.edit().apply {
+                if (hadEnabled) {
+                    putBoolean(HealthConnectBackend.ENABLED_KEY, wasEnabled)
+                } else {
+                    remove(HealthConnectBackend.ENABLED_KEY)
+                }
+            }.commit()
+        }
+
+        assertTrue(succeeded == true)
+    }
+
+    @Test
+    fun testCancelledWorkHasNoResult() = runBlocking {
+        val request = OneTimeWorkRequestBuilder<HealthConnectWorker>()
+            .setInitialDelay(1, TimeUnit.DAYS)
+            .setInputData(
+                workDataOf(
+                    HealthConnectBackend.OPERATION_KEY to
+                        HealthConnectBackend.Operation.WRITE.name,
+                    HealthConnectBackend.USER_INITIATED_KEY to true
+                )
+            )
+            .build()
+        val workManager = WorkManager.getInstance(context)
+        workManager.enqueue(request)
+        workManager.getWorkInfoByIdFlow(request.id).filterNotNull().first()
+        workManager.cancelWorkById(request.id)
+
+        val succeeded = HealthConnectBackend.awaitSuccess(context, request.id)
+
+        assertNull(succeeded)
+    }
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectWorkTest.kt
+++ b/app/src/androidTest/java/hu/vmiklos/plees_tracker/HealthConnectWorkTest.kt
@@ -9,14 +9,19 @@ package hu.vmiklos.plees_tracker
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.ListenableWorker
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
+import java.io.IOException
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,6 +30,61 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class HealthConnectWorkTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun testActiveCancellationIsRethrown() {
+        assertThrows(CancellationException::class.java) {
+            runBlocking {
+                HealthConnectWorker.runOperation(
+                    HealthConnectBackend.Operation.WRITE,
+                    userInitiated = false
+                ) {
+                    throw CancellationException("work replaced")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testAutomaticFailureIsRetried() = runBlocking {
+        val result = HealthConnectWorker.runOperation(
+            HealthConnectBackend.Operation.WRITE,
+            userInitiated = false
+        ) {
+            throw IOException("temporarily unavailable")
+        }
+
+        assertEquals(ListenableWorker.Result.retry(), result)
+    }
+
+    @Test
+    fun testAutomaticPermissionFailureIsNotRetried() = runBlocking {
+        val result = HealthConnectWorker.runOperation(
+            HealthConnectBackend.Operation.WRITE,
+            userInitiated = false
+        ) {
+            throw SecurityException("permission unavailable")
+        }
+
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun testUserInitiatedFailureIsReported() = runBlocking {
+        val result = HealthConnectWorker.runOperation(
+            HealthConnectBackend.Operation.RECONCILE,
+            userInitiated = true
+        ) {
+            throw IOException("temporarily unavailable")
+        }
+
+        assertEquals(
+            ListenableWorker.Result.success(
+                workDataOf(HealthConnectBackend.FAILED_KEY to true)
+            ),
+            result
+        )
+    }
 
     @Test
     fun testSuccessfulWorkResultIsReported() = runBlocking {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DataModel.kt
@@ -265,13 +265,19 @@ object DataModel {
     }
 
     suspend fun deleteSleep(sleep: Sleep) {
-        database.withTransaction {
-            if (sleep.healthConnectId.isNotEmpty()) {
-                database.healthConnectDao().insertDeletions(listOf(deletionFor(sleep)))
-            }
-            database.sleepDao().delete(sleep)
-        }
+        deleteSleepFromDatabase(sleep)
         scheduleHealthConnectSync()
+    }
+
+    internal suspend fun deleteSleepFromDatabase(sleep: Sleep) {
+        database.withTransaction {
+            val current = database.sleepDao().getByIdOrNull(sleep.sid)
+                ?: return@withTransaction
+            if (current.healthConnectId.isNotEmpty()) {
+                database.healthConnectDao().insertDeletions(listOf(deletionFor(current)))
+            }
+            database.sleepDao().delete(current)
+        }
     }
 
     suspend fun deleteAllSleep() {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
@@ -26,11 +26,13 @@ import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
+import androidx.work.workDataOf
 import java.time.Instant
 import java.util.UUID
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 
 /** Health Connect availability, permission, scheduling, and record synchronization. */
 object HealthConnectBackend {
@@ -43,15 +45,23 @@ object HealthConnectBackend {
     internal const val LOCAL_PREFERENCES_NAME = "health_connect_local"
     internal const val READ_CUTOFF_KEY = "health_connect_read_cutoff"
     internal const val HEALTH_CONNECT_BATCH_SIZE = 1000
+    internal const val OPERATION_KEY = "operation"
+    internal const val USER_INITIATED_KEY = "user_initiated"
+    internal const val FAILED_KEY = "failed"
     private const val WORK_NAME = "health_connect_sync"
     private const val LEGACY_READ_MILLIS = 30L * 24 * 60 * 60 * 1000
     private const val TAG = "HealthConnectBackend"
-    private val operationMutex = Mutex()
 
     enum class Availability {
         UNAVAILABLE,
         UPDATE_REQUIRED,
         AVAILABLE
+    }
+
+    internal enum class Operation {
+        WRITE,
+        RECONCILE,
+        WIPE
     }
 
     fun sdkStatus(context: Context): Int {
@@ -80,16 +90,77 @@ object HealthConnectBackend {
             .apply()
     }
 
+    private fun enqueue(
+        context: Context,
+        operation: Operation,
+        userInitiated: Boolean,
+        policy: ExistingWorkPolicy
+    ): UUID {
+        val request = OneTimeWorkRequestBuilder<HealthConnectWorker>()
+            .setInputData(
+                workDataOf(
+                    OPERATION_KEY to operation.name,
+                    USER_INITIATED_KEY to userInitiated
+                )
+            )
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(WORK_NAME, policy, request)
+        return request.id
+    }
+
     fun scheduleSync(context: Context) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P || !isEnabled(context)) {
             return
         }
-        val request = OneTimeWorkRequestBuilder<HealthConnectWorker>().build()
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            WORK_NAME,
-            ExistingWorkPolicy.REPLACE,
-            request
+        enqueue(
+            context,
+            Operation.WRITE,
+            userInitiated = false,
+            ExistingWorkPolicy.APPEND_OR_REPLACE
         )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    suspend fun scheduleReconcile(context: Context) {
+        if (!isEnabled(context) || !hasForegroundWork(readablePeriodStart(context))) {
+            return
+        }
+        enqueue(
+            context,
+            Operation.RECONCILE,
+            userInitiated = false,
+            ExistingWorkPolicy.APPEND_OR_REPLACE
+        )
+    }
+
+    fun forceReconcile(context: Context): UUID? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P || !isEnabled(context)) {
+            return null
+        }
+        return enqueue(
+            context,
+            Operation.RECONCILE,
+            userInitiated = true,
+            ExistingWorkPolicy.REPLACE
+        )
+    }
+
+    fun scheduleWipe(context: Context): UUID? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            return null
+        }
+        return enqueue(context, Operation.WIPE, userInitiated = true, ExistingWorkPolicy.REPLACE)
+    }
+
+    internal suspend fun awaitSuccess(context: Context, id: UUID): Boolean? {
+        val info = WorkManager.getInstance(context)
+            .getWorkInfoByIdFlow(id)
+            .filterNotNull()
+            .first { it.state.isFinished }
+        if (info.state != WorkInfo.State.SUCCEEDED) {
+            return null
+        }
+        return !info.outputData.getBoolean(FAILED_KEY, false)
     }
 
     fun cancelSync(context: Context) {
@@ -215,28 +286,24 @@ object HealthConnectBackend {
     }
 
     @RequiresApi(Build.VERSION_CODES.P)
-    suspend fun write(context: Context) {
-        if (!isEnabled(context)) {
+    internal suspend fun perform(context: Context, operation: Operation) {
+        if (operation != Operation.WIPE && !isEnabled(context)) {
             return
         }
         val client = HealthConnectClient.getOrCreate(context)
-        operationMutex.withLock {
-            write(client)
-        }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.P)
-    suspend fun reconcileForeground(context: Context, force: Boolean = false) {
-        if (!isEnabled(context)) {
-            return
-        }
-        val readablePeriodStart = readablePeriodStart(context)
-        if (!force && !hasForegroundWork(readablePeriodStart)) {
-            return
-        }
-        val client = HealthConnectClient.getOrCreate(context)
-        operationMutex.withLock {
-            sync(client, context.packageName, readablePeriodStart)
+        when (operation) {
+            Operation.WRITE -> write(client)
+            Operation.RECONCILE -> sync(
+                client,
+                context.packageName,
+                readablePeriodStart(context)
+            )
+            Operation.WIPE -> {
+                check(canReadAllHistory(context)) {
+                    "Health Connect cannot expose all owned records on this system module"
+                }
+                wipe(client, context.packageName)
+            }
         }
     }
 
@@ -245,18 +312,6 @@ object HealthConnectBackend {
         val after = readablePeriodStart.toEpochMilli()
         return DataModel.database.sleepDao().hasPendingHealthConnectWrites(after) ||
             DataModel.database.healthConnectDao().hasDeletions(after)
-    }
-
-    /** Deletes every sleep record whose Health Connect data origin is this app. */
-    @RequiresApi(Build.VERSION_CODES.P)
-    suspend fun wipe(context: Context) {
-        check(canReadAllHistory(context)) {
-            "Health Connect cannot expose all owned records on this system module"
-        }
-        val client = HealthConnectClient.getOrCreate(context)
-        operationMutex.withLock {
-            wipe(client, context.packageName)
-        }
     }
 
     @RequiresApi(Build.VERSION_CODES.P)

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
@@ -112,6 +112,7 @@ object HealthConnectBackend {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P || !isEnabled(context)) {
             return
         }
+        // Preserve edit order; a failed or cancelled chain starts fresh with this request.
         enqueue(
             context,
             Operation.WRITE,
@@ -120,11 +121,11 @@ object HealthConnectBackend {
         )
     }
 
-    @RequiresApi(Build.VERSION_CODES.P)
-    suspend fun scheduleReconcile(context: Context) {
-        if (!isEnabled(context) || !hasForegroundWork(readablePeriodStart(context))) {
+    fun scheduleReconcile(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P || !isEnabled(context)) {
             return
         }
+        // Check for pending work when this request runs, after earlier queued writes finish.
         enqueue(
             context,
             Operation.RECONCILE,
@@ -137,6 +138,7 @@ object HealthConnectBackend {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P || !isEnabled(context)) {
             return null
         }
+        // A force sync supersedes queued writes because reconciliation uploads local changes too.
         return enqueue(
             context,
             Operation.RECONCILE,
@@ -149,6 +151,7 @@ object HealthConnectBackend {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             return null
         }
+        // Wiping supersedes every queued operation and must not be followed by an older write.
         return enqueue(context, Operation.WIPE, userInitiated = true, ExistingWorkPolicy.REPLACE)
     }
 
@@ -286,23 +289,32 @@ object HealthConnectBackend {
     }
 
     @RequiresApi(Build.VERSION_CODES.P)
-    internal suspend fun perform(context: Context, operation: Operation) {
+    internal suspend fun perform(
+        context: Context,
+        operation: Operation,
+        forceReconcile: Boolean = false
+    ) {
         if (operation != Operation.WIPE && !isEnabled(context)) {
             return
         }
-        val client = HealthConnectClient.getOrCreate(context)
         when (operation) {
-            Operation.WRITE -> write(client)
-            Operation.RECONCILE -> sync(
-                client,
-                context.packageName,
-                readablePeriodStart(context)
-            )
+            Operation.WRITE -> write(HealthConnectClient.getOrCreate(context))
+            Operation.RECONCILE -> {
+                val readablePeriodStart = readablePeriodStart(context)
+                if (!forceReconcile && !hasForegroundWork(readablePeriodStart)) {
+                    return
+                }
+                sync(
+                    HealthConnectClient.getOrCreate(context),
+                    context.packageName,
+                    readablePeriodStart
+                )
+            }
             Operation.WIPE -> {
                 check(canReadAllHistory(context)) {
                     "Health Connect cannot expose all owned records on this system module"
                 }
-                wipe(client, context.packageName)
+                wipe(HealthConnectClient.getOrCreate(context), context.packageName)
             }
         }
     }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectBackend.kt
@@ -422,13 +422,22 @@ object HealthConnectBackend {
     }
 
     @RequiresApi(Build.VERSION_CODES.P)
-    private suspend fun write(client: HealthConnectClient, sleeps: List<Sleep>) {
+    internal suspend fun write(client: HealthConnectClient, sleeps: List<Sleep>) {
         val healthDao = DataModel.database.healthConnectDao()
-        for (sleep in sleeps.filter { it.healthConnectId.isEmpty() }) {
-            sleep.healthConnectId = UUID.randomUUID().toString()
-            healthDao.assignId(sleep.sid, sleep.healthConnectId)
+        val writableSleeps = sleeps.filter { sleep ->
+            if (sleep.healthConnectId.isNotEmpty()) {
+                true
+            } else {
+                val id = UUID.randomUUID().toString()
+                if (healthDao.assignId(sleep.sid, id) == 1) {
+                    sleep.healthConnectId = id
+                    true
+                } else {
+                    false
+                }
+            }
         }
-        for (chunk in sleeps.chunked(HEALTH_CONNECT_BATCH_SIZE)) {
+        for (chunk in writableSleeps.chunked(HEALTH_CONNECT_BATCH_SIZE)) {
             client.insertRecords(chunk.map(::toRecord))
             // Persist progress after every successful provider batch. The version predicate in
             // markVersionSynced prevents a concurrent edit from being marked as uploaded.

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectDao.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectDao.kt
@@ -33,7 +33,7 @@ interface HealthConnectDao {
     }
 
     @Query("UPDATE sleep SET health_connect_id = :id WHERE sid = :sid AND health_connect_id = ''")
-    suspend fun assignId(sid: Int, id: String)
+    suspend fun assignId(sid: Int, id: String): Int
 
     @Query(
         "UPDATE sleep SET health_connect_version = :version " +

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectWorker.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectWorker.kt
@@ -15,7 +15,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 
-/** Writes Plees Tracker's local sleeps without reading Health Connect in the background. */
+/** Runs serialized Health Connect writes, reconciliations, and wipes. */
 class HealthConnectWorker(context: Context, params: WorkerParameters) :
     CoroutineWorker(context, params) {
     override suspend fun doWork(): Result {
@@ -29,14 +29,18 @@ class HealthConnectWorker(context: Context, params: WorkerParameters) :
         val userInitiated = inputData.getBoolean(HealthConnectBackend.USER_INITIATED_KEY, false)
         DataModel.init(context, PreferenceManager.getDefaultSharedPreferences(context))
         return try {
-            HealthConnectBackend.perform(context, operation)
+            HealthConnectBackend.perform(
+                context,
+                operation,
+                forceReconcile = userInitiated
+            )
             Result.success()
         } catch (e: SecurityException) {
             Log.e(TAG, "doWork: Health Connect permission unavailable: $e")
-            errorResult(userInitiated)
+            if (userInitiated) userFailure() else Result.success()
         } catch (e: Exception) {
             Log.e(TAG, "doWork: $operation failed: $e")
-            if (userInitiated) errorResult(true) else Result.retry()
+            if (userInitiated) userFailure() else Result.retry()
         }
     }
 
@@ -50,12 +54,9 @@ class HealthConnectWorker(context: Context, params: WorkerParameters) :
         }
     }
 
-    private fun errorResult(userInitiated: Boolean): Result =
-        if (userInitiated) {
-            Result.success(workDataOf(HealthConnectBackend.FAILED_KEY to true))
-        } else {
-            Result.success()
-        }
+    // Keep a completed WorkInfo available so the settings screen can report the failure.
+    private fun userFailure(): Result =
+        Result.success(workDataOf(HealthConnectBackend.FAILED_KEY to true))
 
     companion object {
         private const val TAG = "HealthConnectWorker"

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectWorker.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectWorker.kt
@@ -14,6 +14,7 @@ import androidx.preference.PreferenceManager
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import kotlinx.coroutines.CancellationException
 
 /** Runs serialized Health Connect writes, reconciliations, and wipes. */
 class HealthConnectWorker(context: Context, params: WorkerParameters) :
@@ -28,19 +29,12 @@ class HealthConnectWorker(context: Context, params: WorkerParameters) :
         val operation = operation() ?: return Result.success()
         val userInitiated = inputData.getBoolean(HealthConnectBackend.USER_INITIATED_KEY, false)
         DataModel.init(context, PreferenceManager.getDefaultSharedPreferences(context))
-        return try {
+        return runOperation(operation, userInitiated) {
             HealthConnectBackend.perform(
                 context,
                 operation,
                 forceReconcile = userInitiated
             )
-            Result.success()
-        } catch (e: SecurityException) {
-            Log.e(TAG, "doWork: Health Connect permission unavailable: $e")
-            if (userInitiated) userFailure() else Result.success()
-        } catch (e: Exception) {
-            Log.e(TAG, "doWork: $operation failed: $e")
-            if (userInitiated) userFailure() else Result.retry()
         }
     }
 
@@ -54,12 +48,29 @@ class HealthConnectWorker(context: Context, params: WorkerParameters) :
         }
     }
 
-    // Keep a completed WorkInfo available so the settings screen can report the failure.
-    private fun userFailure(): Result =
-        Result.success(workDataOf(HealthConnectBackend.FAILED_KEY to true))
-
     companion object {
         private const val TAG = "HealthConnectWorker"
+
+        internal suspend fun runOperation(
+            operation: HealthConnectBackend.Operation,
+            userInitiated: Boolean,
+            block: suspend () -> Unit
+        ): Result = try {
+            block()
+            Result.success()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: SecurityException) {
+            Log.e(TAG, "runOperation: Health Connect permission unavailable: $e")
+            if (userInitiated) userFailure() else Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "runOperation: $operation failed: $e")
+            if (userInitiated) userFailure() else Result.retry()
+        }
+
+        // Keep a completed WorkInfo available so the settings screen can report the failure.
+        private fun userFailure(): Result =
+            Result.success(workDataOf(HealthConnectBackend.FAILED_KEY to true))
     }
 }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectWorker.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/HealthConnectWorker.kt
@@ -13,6 +13,7 @@ import androidx.health.connect.client.HealthConnectClient
 import androidx.preference.PreferenceManager
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import androidx.work.workDataOf
 
 /** Writes Plees Tracker's local sleeps without reading Health Connect in the background. */
 class HealthConnectWorker(context: Context, params: WorkerParameters) :
@@ -24,18 +25,37 @@ class HealthConnectWorker(context: Context, params: WorkerParameters) :
         ) {
             return Result.success()
         }
+        val operation = operation() ?: return Result.success()
+        val userInitiated = inputData.getBoolean(HealthConnectBackend.USER_INITIATED_KEY, false)
         DataModel.init(context, PreferenceManager.getDefaultSharedPreferences(context))
         return try {
-            HealthConnectBackend.write(context)
+            HealthConnectBackend.perform(context, operation)
             Result.success()
         } catch (e: SecurityException) {
             Log.e(TAG, "doWork: Health Connect permission unavailable: $e")
-            Result.success()
+            errorResult(userInitiated)
         } catch (e: Exception) {
-            Log.e(TAG, "doWork: synchronization failed: $e")
-            Result.retry()
+            Log.e(TAG, "doWork: $operation failed: $e")
+            if (userInitiated) errorResult(true) else Result.retry()
         }
     }
+
+    private fun operation(): HealthConnectBackend.Operation? {
+        val name = inputData.getString(HealthConnectBackend.OPERATION_KEY) ?: return null
+        return try {
+            HealthConnectBackend.Operation.valueOf(name)
+        } catch (e: IllegalArgumentException) {
+            Log.e(TAG, "operation: unknown operation '$name': $e")
+            null
+        }
+    }
+
+    private fun errorResult(userInitiated: Boolean): Result =
+        if (userInitiated) {
+            Result.success(workDataOf(HealthConnectBackend.FAILED_KEY to true))
+        } else {
+            Result.success()
+        }
 
     companion object {
         private const val TAG = "HealthConnectWorker"

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -138,7 +138,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
             lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     try {
-                        HealthConnectBackend.reconcileForeground(applicationContext)
+                        HealthConnectBackend.scheduleReconcile(applicationContext)
                     } catch (e: SecurityException) {
                         Log.e(TAG, "Health Connect permission unavailable: $e")
                     } catch (e: Exception) {

--- a/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/MainActivity.kt
@@ -137,14 +137,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    try {
-                        HealthConnectBackend.scheduleReconcile(applicationContext)
-                    } catch (e: SecurityException) {
-                        Log.e(TAG, "Health Connect permission unavailable: $e")
-                    } catch (e: Exception) {
-                        // Keep tombstones for the next foreground session.
-                        Log.e(TAG, "Health Connect foreground reconciliation failed: $e")
-                    }
+                    HealthConnectBackend.scheduleReconcile(applicationContext)
                 }
             }
         }

--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -423,12 +423,14 @@ class PreferencesActivity : AppCompatActivity() {
                 skipButton.isEnabled = false
                 wipeButton.isEnabled = false
                 lifecycleScope.launch {
-                    try {
-                        HealthConnectBackend.wipe(applicationContext)
+                    val work = HealthConnectBackend.scheduleWipe(applicationContext)
+                    if (work != null &&
+                        HealthConnectBackend.awaitSuccess(applicationContext, work) == true
+                    ) {
                         dialog.dismiss()
                         finishHealthConnectEnable()
-                    } catch (e: Exception) {
-                        Log.e(TAG, "wipeHealthConnect: $e")
+                    } else {
+                        Log.e(TAG, "wipeHealthConnect: the wipe did not complete")
                         toast(R.string.health_connect_temporarily_unavailable)
                         importButton.isEnabled = true
                         skipButton.isEnabled = true
@@ -464,21 +466,20 @@ class PreferencesActivity : AppCompatActivity() {
     }
 
     private fun forceHealthConnectSync(showResult: Boolean) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+        val work = HealthConnectBackend.forceReconcile(applicationContext) ?: return
+        if (!showResult) {
             return
         }
         lifecycleScope.launch {
-            try {
-                HealthConnectBackend.reconcileForeground(applicationContext, force = true)
-                if (showResult) {
-                    toast(R.string.health_connect_force_sync_finished)
+            val succeeded =
+                HealthConnectBackend.awaitSuccess(applicationContext, work) ?: return@launch
+            toast(
+                if (succeeded) {
+                    R.string.health_connect_force_sync_finished
+                } else {
+                    R.string.health_connect_temporarily_unavailable
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "forceHealthConnectSync: $e")
-                if (showResult) {
-                    toast(R.string.health_connect_temporarily_unavailable)
-                }
-            }
+            )
         }
     }
 

--- a/app/src/main/java/hu/vmiklos/plees_tracker/SleepDao.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/SleepDao.kt
@@ -41,6 +41,9 @@ interface SleepDao {
     @Query("SELECT * from sleep where sid = :id LIMIT 1")
     suspend fun getById(id: Int): Sleep
 
+    @Query("SELECT * from sleep where sid = :id LIMIT 1")
+    suspend fun getByIdOrNull(id: Int): Sleep?
+
     @Query("SELECT * FROM sleep WHERE stop_date > :after ORDER BY start_date DESC")
     fun getAfterLive(after: Long): LiveData<List<Sleep>>
 


### PR DESCRIPTION
Added tests and cleaned up WorkManager implementation for Health Connect sync. 

Fixed the data race between UUID assignment and deletion by retrieving the record before deletion, and checking if the record still exists during UUID assignment. 