### PR TITLE
Update play-services-auth to 22.0.0 by porting off the removed GoogleSignIn API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,7 +122,7 @@ dependencies {
 
     // gplay flavor only: Google Drive (appDataFolder) backup. These are proprietary and are kept
     // out of the foss flavor so the F-Droid build stays free of Google dependencies.
-    gplayImplementation 'com.google.android.gms:play-services-auth:21.6.0'
+    gplayImplementation 'com.google.android.gms:play-services-auth:22.0.0'
     gplayImplementation('com.google.api-client:google-api-client-android:2.9.0') {
         exclude group: 'org.apache.httpcomponents'
         exclude group: 'com.google.guava', module: 'guava-jdk5'

--- a/app/src/foss/java/hu/vmiklos/plees_tracker/DriveBackend.kt
+++ b/app/src/foss/java/hu/vmiklos/plees_tracker/DriveBackend.kt
@@ -18,12 +18,18 @@ object DriveBackend {
     // constant conditions, which the warnings-as-errors build rejects.
     val isSupported = false
 
-    fun createSignInIntent(context: Context): Intent? = null
+    fun createAccountPickerIntent(): Intent? = null
 
-    suspend fun handleSignInResult(context: Context, data: Intent?): DriveSignInResult =
-        DriveSignInResult.Cancelled
+    fun readPickedAccount(data: Intent?): String? = null
 
-    fun signOut(context: Context) {}
+    suspend fun authorize(context: Context, email: String): DriveAuthorization =
+        DriveAuthorization.Failed
+
+    suspend fun handleAuthorizationResult(
+        context: Context,
+        email: String,
+        data: Intent?
+    ): DriveSignInResult = DriveSignInResult.Cancelled
 
     fun isAccountOnDevice(context: Context, email: String): Boolean = false
 

--- a/app/src/gplay/java/hu/vmiklos/plees_tracker/DriveBackend.kt
+++ b/app/src/gplay/java/hu/vmiklos/plees_tracker/DriveBackend.kt
@@ -4,12 +4,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-// The classic GoogleSignIn API is deprecated in favor of Credential Manager + the Identity
-// AuthorizationClient, but it stays the simplest, best-documented way to obtain Drive appDataFolder
-// authorization and still works at runtime. Suppress the deprecation warnings so the -Werror build
-// passes; migrating to AuthorizationClient would be a future improvement.
-@file:Suppress("DEPRECATION")
-
 package hu.vmiklos.plees_tracker
 
 import android.accounts.Account
@@ -25,13 +19,13 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.auth.api.signin.GoogleSignInClient
-import com.google.android.gms.auth.api.signin.GoogleSignInOptions
-import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes
+import com.google.android.gms.auth.api.identity.AuthorizationRequest
+import com.google.android.gms.auth.api.identity.AuthorizationResult
+import com.google.android.gms.auth.api.identity.Identity
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.Scope
+import com.google.android.gms.tasks.Tasks
 import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential
 import com.google.api.client.http.ByteArrayContent
 import com.google.api.client.http.javanet.NetHttpTransport
@@ -54,6 +48,8 @@ object DriveBackend {
 
     private const val BACKUP_NAME = "backup.csv"
 
+    private const val ACCOUNT_TYPE = "com.google"
+
     // WorkManager work-name prefixes; a per-account suffix (the email) makes them unique per
     // account.
     private const val WORK_NAME_PREFIX = "drive_backup_"
@@ -62,51 +58,89 @@ object DriveBackend {
     // Not a const val on purpose: see the foss flavor's DriveBackend for the rationale.
     val isSupported = true
 
-    fun createSignInIntent(context: Context): Intent? = signInClient(context).signInIntent
+    /**
+     * Intent for the system Google account picker, which always prompts, so there is no sign-in
+     * state to clear before adding or changing an account.
+     *
+     * Naming the account and authorizing Drive are two separate steps: the picker gives back the
+     * email that keys the whole destination and that [driveService] needs as a device account,
+     * then [authorize] asks Play Services for the appDataFolder scope on its behalf.
+     */
+    fun createAccountPickerIntent(): Intent? = AccountManager.newChooseAccountIntent(
+        null, null, arrayOf(ACCOUNT_TYPE), null, null, null, null
+    )
 
-    /** Processes the result of the Drive sign-in activity. */
-    suspend fun handleSignInResult(context: Context, data: Intent?): DriveSignInResult =
+    /** Email of the account picked in the account picker, null when the user backed out of it. */
+    fun readPickedAccount(data: Intent?): String? =
+        data?.getStringExtra(AccountManager.KEY_ACCOUNT_NAME)
+
+    /**
+     * Requests the Drive appDataFolder scope for [email]. Returns [DriveAuthorization.Consent]
+     * when Play Services wants the user to confirm the grant first -- the normal case for an
+     * account authorized for the first time -- carrying the intent only an activity can launch.
+     */
+    suspend fun authorize(context: Context, email: String): DriveAuthorization =
         withContext(Dispatchers.IO) {
-            if (data == null) {
-                // No result payload at all: the user backed out before picking an account.
-                return@withContext DriveSignInResult.Cancelled
-            }
+            val request = AuthorizationRequest.Builder()
+                .setRequestedScopes(listOf(appDataScope()))
+                .setAccount(Account(email, ACCOUNT_TYPE))
+                .build()
             try {
-                val account = GoogleSignIn.getSignedInAccountFromIntent(data)
-                    .getResult(ApiException::class.java)
-                val email = account?.email
-                if (email == null) {
-                    Log.e(TAG, "handleSignInResult: no account in result")
-                    return@withContext DriveSignInResult.Failed
+                // Blocking await: this already runs off the main thread, and it keeps the
+                // callers plain suspending code without a coroutines-play-services dependency.
+                val result = Tasks.await(
+                    Identity.getAuthorizationClient(context).authorize(request)
+                )
+                val pendingIntent = result.pendingIntent
+                when {
+                    result.hasResolution() && pendingIntent != null ->
+                        DriveAuthorization.Consent(pendingIntent)
+                    isAppDataGranted(result) -> DriveAuthorization.Granted
+                    else -> {
+                        Log.e(TAG, "authorize($email): drive.appdata scope not granted")
+                        DriveAuthorization.Failed
+                    }
                 }
-                if (!GoogleSignIn.hasPermissions(account, appDataScope())) {
-                    Log.e(TAG, "handleSignInResult: drive.appdata scope not granted")
-                    return@withContext DriveSignInResult.Failed
-                }
-                DriveSignInResult.Success(email)
-            } catch (e: ApiException) {
-                if (e.statusCode == GoogleSignInStatusCodes.SIGN_IN_CANCELLED ||
-                    e.statusCode == CommonStatusCodes.CANCELED
-                ) {
-                    DriveSignInResult.Cancelled
-                } else {
-                    Log.e(TAG, "handleSignInResult: sign-in failed, status=${e.statusCode}")
-                    DriveSignInResult.Failed
-                }
+            } catch (e: Exception) {
+                Log.e(TAG, "authorize($email): $e")
+                DriveAuthorization.Failed
             }
         }
 
     /**
-     * Signs out from GoogleSignIn. Called before adding a new account so the sign-in flow always
-     * shows the account picker rather than silently reusing the previous account.
+     * Processes the result of the consent activity launched for [DriveAuthorization.Consent].
+     * [email] is the account the consent was asked for, so that a success can name it.
      */
-    fun signOut(context: Context) {
-        signInClient(context).signOut()
+    suspend fun handleAuthorizationResult(
+        context: Context,
+        email: String,
+        data: Intent?
+    ): DriveSignInResult = withContext(Dispatchers.IO) {
+        if (data == null) {
+            // No result payload at all: the user backed out of the consent screen.
+            return@withContext DriveSignInResult.Cancelled
+        }
+        try {
+            val result = Identity.getAuthorizationClient(context)
+                .getAuthorizationResultFromIntent(data)
+            if (!isAppDataGranted(result)) {
+                Log.e(TAG, "handleAuthorizationResult: drive.appdata scope not granted")
+                return@withContext DriveSignInResult.Failed
+            }
+            DriveSignInResult.Success(email)
+        } catch (e: ApiException) {
+            if (e.statusCode == CommonStatusCodes.CANCELED) {
+                DriveSignInResult.Cancelled
+            } else {
+                Log.e(TAG, "handleAuthorizationResult: failed, status=${e.statusCode}")
+                DriveSignInResult.Failed
+            }
+        }
     }
 
     /** True when the given email corresponds to a Google account still present on the device. */
     fun isAccountOnDevice(context: Context, email: String): Boolean = try {
-        AccountManager.get(context).getAccountsByType("com.google").any { it.name == email }
+        AccountManager.get(context).getAccountsByType(ACCOUNT_TYPE).any { it.name == email }
     } catch (_: Exception) {
         true // Can't verify; assume valid so callers don't silently drop the account.
     }
@@ -222,19 +256,13 @@ object DriveBackend {
 
     private fun appDataScope() = Scope(DriveScopes.DRIVE_APPDATA)
 
-    private fun signInClient(context: Context): GoogleSignInClient {
-        val options = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestEmail()
-            .requestScopes(appDataScope())
-            .build()
-        return GoogleSignIn.getClient(context, options)
-    }
+    private fun isAppDataGranted(result: AuthorizationResult): Boolean =
+        DriveScopes.DRIVE_APPDATA in result.grantedScopes.orEmpty()
 
     /**
      * Builds a Drive client for [email], or null when the account is no longer on the device.
-     * This builds Account(email, "com.google") directly instead of getLastSignedInAccount(), so
-     * any Google account on the device can be used regardless of which one most recently
-     * completed the sign-in flow.
+     * The token comes from the device account itself, so every configured account keeps working
+     * independently of which one was authorized last.
      */
     private fun driveService(context: Context, email: String): Drive? {
         if (!isAccountOnDevice(context, email)) {
@@ -244,7 +272,7 @@ object DriveBackend {
         val credential = GoogleAccountCredential.usingOAuth2(
             context, listOf(DriveScopes.DRIVE_APPDATA)
         )
-        credential.selectedAccount = Account(email, "com.google")
+        credential.selectedAccount = Account(email, ACCOUNT_TYPE)
         return Drive.Builder(NetHttpTransport(), GsonFactory.getDefaultInstance(), credential)
             .setApplicationName(context.getString(R.string.app_name))
             .build()

--- a/app/src/main/java/hu/vmiklos/plees_tracker/DriveAuthorization.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/DriveAuthorization.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+package hu.vmiklos.plees_tracker
+
+import android.app.PendingIntent
+
+/**
+ * Outcome of asking Play Services for the Drive appDataFolder scope on an account's behalf.
+ * Consent is not an error: it just means Play Services wants to show its consent screen before
+ * granting, which only the activity can launch.
+ */
+sealed class DriveAuthorization {
+    /** The account already granted the scope, no user interaction is needed. */
+    object Granted : DriveAuthorization()
+    data class Consent(val pendingIntent: PendingIntent) : DriveAuthorization()
+    object Failed : DriveAuthorization()
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -15,6 +15,7 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
@@ -41,6 +42,7 @@ class PreferencesActivity : AppCompatActivity() {
         private const val STATE_CHANGE_PATH_FROM = "changePathFrom"
         private const val STATE_CHANGE_ACCOUNT_EMAIL = "changeAccountEmail"
         private const val STATE_CHANGE_ACCOUNT_FREQUENCY = "changeAccountFrequency"
+        private const val STATE_AUTHORIZE_EMAIL = "authorizeEmail"
         private const val STATE_HEALTH_SETTINGS_PENDING = "healthSettingsPending"
         private const val STATE_HEALTH_CHECK_PENDING = "healthCheckPending"
         private const val HEALTH_CONNECT_WIPE_DELAY_SECONDS = 5
@@ -72,6 +74,10 @@ class PreferencesActivity : AppCompatActivity() {
     // The destination whose account is being replaced by "Change account". Null means the
     // sign-in result adds a new destination instead.
     private var changeAccountFrom: BackupDestination.DriveAccount? = null
+
+    // The picked account whose Drive consent screen is on screen. The consent result only says
+    // which scopes were granted, so the email it belongs to is remembered here.
+    private var authorizeEmail: String? = null
 
     // True while Health Connect's app-specific settings were opened from the enable flow. This
     // lets a permission granted there complete the opt-in when the user returns to Plees.
@@ -123,6 +129,7 @@ class PreferencesActivity : AppCompatActivity() {
             if (email != null && frequency != null) {
                 changeAccountFrom = BackupDestination.DriveAccount(email, frequency)
             }
+            authorizeEmail = state.getString(STATE_AUTHORIZE_EMAIL)
             healthSettingsPending = state.getBoolean(STATE_HEALTH_SETTINGS_PENDING)
         }
         val persistedCheckPending = HealthConnectBackend.localPreferences(applicationContext)
@@ -491,6 +498,7 @@ class PreferencesActivity : AppCompatActivity() {
         outState.putString(STATE_CHANGE_PATH_FROM, changePathFrom?.path)
         outState.putString(STATE_CHANGE_ACCOUNT_EMAIL, changeAccountFrom?.email)
         outState.putString(STATE_CHANGE_ACCOUNT_FREQUENCY, changeAccountFrom?.frequency)
+        outState.putString(STATE_AUTHORIZE_EMAIL, authorizeEmail)
         outState.putBoolean(STATE_HEALTH_SETTINGS_PENDING, healthSettingsPending)
         outState.putBoolean(STATE_HEALTH_CHECK_PENDING, healthConnectCheckPending)
     }
@@ -644,35 +652,79 @@ class PreferencesActivity : AppCompatActivity() {
         }
     }
 
-    private val driveSignInResult =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            val changeFrom = changeAccountFrom
-            changeAccountFrom = null
-            val replaceFolder = replaceFolderOnSignIn
-            replaceFolderOnSignIn = null
+    // Second step of adding a Drive account: the Play Services consent screen, shown only when
+    // the account has not granted the appDataFolder scope to this app yet.
+    private val driveConsentResult =
+        registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+            val email = authorizeEmail
+            authorizeEmail = null
             lifecycleScope.launch {
-                val signIn = DriveBackend.handleSignInResult(applicationContext, result.data)
-                when (signIn) {
-                    is DriveSignInResult.Success -> if (changeFrom != null) {
-                        applyAccountChange(changeFrom, signIn.email)
+                finishDriveSignIn(
+                    if (email == null) {
+                        DriveSignInResult.Failed
                     } else {
-                        addDriveDestination(signIn.email)
-                        toast(R.string.drive_sign_in_success)
-                        if (replaceFolder != null) {
-                            // "Instead of the device folder": Drive is in place, retire the
-                            // folder destination and offer to clean up its backup file.
-                            DataModel.removeDestination(replaceFolder)
-                            releaseFolderPermission(replaceFolder.path)
-                            confirmDeleteRetiredFolderBackup(replaceFolder)
-                        }
+                        DriveBackend.handleAuthorizationResult(
+                            applicationContext, email, result.data
+                        )
                     }
-                    // Backing out of the account picker is a deliberate choice, not an error.
-                    DriveSignInResult.Cancelled -> {}
-                    DriveSignInResult.Failed -> toast(R.string.drive_sign_in_failure)
-                }
-                refreshFragment()
+                )
             }
         }
+
+    // First step of adding a Drive account: the system account picker, which names the account
+    // the destination is keyed by.
+    private val driveAccountPickerResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            val email = DriveBackend.readPickedAccount(result.data)
+            if (email == null) {
+                // Backing out of the account picker is a deliberate choice, not an error.
+                finishDriveSignIn(DriveSignInResult.Cancelled)
+                return@registerForActivityResult
+            }
+            lifecycleScope.launch {
+                when (val authorization = DriveBackend.authorize(applicationContext, email)) {
+                    is DriveAuthorization.Consent -> {
+                        authorizeEmail = email
+                        driveConsentResult.launch(
+                            IntentSenderRequest.Builder(authorization.pendingIntent).build()
+                        )
+                    }
+                    DriveAuthorization.Granted ->
+                        finishDriveSignIn(DriveSignInResult.Success(email))
+                    DriveAuthorization.Failed -> finishDriveSignIn(DriveSignInResult.Failed)
+                }
+            }
+        }
+
+    /**
+     * Applies the outcome of a Drive sign-in and consumes the pending state of the flow that
+     * started it, no matter which of the two steps the flow ended at.
+     */
+    private fun finishDriveSignIn(signIn: DriveSignInResult) {
+        val changeFrom = changeAccountFrom
+        changeAccountFrom = null
+        val replaceFolder = replaceFolderOnSignIn
+        replaceFolderOnSignIn = null
+        when (signIn) {
+            is DriveSignInResult.Success -> if (changeFrom != null) {
+                applyAccountChange(changeFrom, signIn.email)
+            } else {
+                addDriveDestination(signIn.email)
+                toast(R.string.drive_sign_in_success)
+                if (replaceFolder != null) {
+                    // "Instead of the device folder": Drive is in place, retire the
+                    // folder destination and offer to clean up its backup file.
+                    DataModel.removeDestination(replaceFolder)
+                    releaseFolderPermission(replaceFolder.path)
+                    confirmDeleteRetiredFolderBackup(replaceFolder)
+                }
+            }
+            // Backing out of the flow is a deliberate choice, not an error.
+            DriveSignInResult.Cancelled -> {}
+            DriveSignInResult.Failed -> toast(R.string.drive_sign_in_failure)
+        }
+        refreshFragment()
+    }
 
     private fun addDriveDestination(email: String) {
         // The result can arrive twice for the same account, e.g. when the activity was
@@ -796,11 +848,8 @@ class PreferencesActivity : AppCompatActivity() {
     }
 
     private fun addDriveAccount() {
-        // Sign out first so GoogleSignIn shows the account picker rather than silently reusing
-        // whichever account last completed the flow (e.g. one removed just before).
-        DriveBackend.signOut(this)
-        val intent = DriveBackend.createSignInIntent(this) ?: return
-        driveSignInResult.launch(intent)
+        val intent = DriveBackend.createAccountPickerIntent() ?: return
+        driveAccountPickerResult.launch(intent)
     }
 
     fun backupNow(email: String) {
@@ -886,11 +935,9 @@ class PreferencesActivity : AppCompatActivity() {
      * fails or is cancelled.
      */
     fun changeDriveAccount(dest: BackupDestination.DriveAccount) {
-        // Sign out first so the picker is shown instead of silently reusing the last account.
-        DriveBackend.signOut(this)
-        val intent = DriveBackend.createSignInIntent(this) ?: return
+        val intent = DriveBackend.createAccountPickerIntent() ?: return
         changeAccountFrom = dest
-        driveSignInResult.launch(intent)
+        driveAccountPickerResult.launch(intent)
     }
 
     private fun applyAccountChange(old: BackupDestination.DriveAccount, newEmail: String) {

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -106,9 +106,9 @@ during exporting to a file. This pretty output can't be imported back, though.
 The Google Drive destination is only available in the `gplay` build flavor (the F-Droid `foss`
 flavor is free of proprietary Google dependencies, so it only offers the folder destination).
 
-When you add Google Drive, you sign in with a Google account and your sleeps are backed up to your
-Drive's hidden per-app storage (the appDataFolder): it's not visible among your normal Drive files
-and is only accessible to this app.
+When you add Google Drive, you pick one of the Google accounts of the device and confirm the app's
+Drive access. Your sleeps are then backed up to that account's hidden per-app storage (the
+appDataFolder): it's not visible among your normal Drive files and is only accessible to this app.
 
 A newly added account backs up once a day by default; "Change frequency" switches between "Once a
 day" and "On sleep add / edit / remove". Automatic uploads are skipped when nothing changed since
@@ -133,8 +133,8 @@ Setting this up for a self-built `gplay` flavor requires a Google Cloud project 
 the Drive API, add the `.../auth/drive.appdata` scope to the OAuth consent screen, and create an
 OAuth 2.0 client ID of type "Android" for the app's package name and signing certificate SHA-1
 fingerprint (register both the release package and the `.debug` package if you test debug builds).
-The `drive.appdata` scope is not "sensitive", so no Google verification review is needed. Sign-in
-fails until this is configured.
+The `drive.appdata` scope is not "sensitive", so no Google verification review is needed.
+Authorizing the account fails until this is configured.
 
 ### Dashboard
 


### PR DESCRIPTION
Answers https://github.com/vmiklos/plees-tracker/pull/596#issuecomment-5546246144 — yes, and here it is.

## Why it isn't a one-line bump

play-services-auth 22.0.0 "removed the APIs related to Google Sign-in" ([release notes](https://developers.google.com/android/guides/releases#august_26_2026)). The Drive backup used four of them, and none survive in the 22.0.0 AAR:

| class | 21.6.0 | 22.0.0 |
| --- | --- | --- |
| `GoogleSignIn` | ✅ | ❌ |
| `GoogleSignInClient` | ✅ | ❌ |
| `GoogleSignInOptions` | ✅ | ❌ |
| `GoogleSignInStatusCodes` | ✅ | ❌ |
| `com.google.android.gms.auth.api.identity.*` | ✅ | ✅ |

So the sign-in has to move off it first; the bump is then trivial. That is the commit split below.

## What replaces it

```
before:  [ GoogleSignIn intent ] ──▶ account + drive.appdata consent, in one dialog
                                     email came from GoogleSignInAccount

after:   [ system account picker ] ──▶ email
                    │                  (AccountManager.newChooseAccountIntent, "com.google")
                    ▼
         [ AuthorizationClient.authorize(drive.appdata, account) ]
                    │
                    ├── already granted ──────────────▶ done
                    └── PendingIntent ─▶ [ consent ] ─▶ done
```

Two notes on the choice:

- **Why not Credential Manager**, which the release notes point at? It replaces *authentication*, and this feature never needed one — it needs *authorization* for a Drive scope on a device account. Going that way would add `androidx.credentials` + `googleid`, plus a Web client ID in the Cloud project setup, and would still need `AuthorizationClient` for the scope itself. This way adds no dependency at all.
- **The email now comes from the system picker.** That is a small correctness win too: `GoogleAccountCredential` needs an `Account(email, "com.google")` that is on the device, which the old flow assumed and the new one guarantees. `GoogleAccountCredential` keeps fetching tokens through `GoogleAuthUtil` exactly as before — the grant store is the same one `GoogleSignIn` wrote to, so **existing users are not signed out**.

`DriveBackend.signOut()` is gone with it: the system picker always prompts, so there is no sign-in state to clear before adding or changing an account. The `@file:Suppress("DEPRECATION")` the `-Werror` build needed for `GoogleSignIn` goes away as well.

## Commits

1. **Port Drive sign-in to the Identity AuthorizationClient** — the whole functional change, still on 21.6.0 so it builds on its own. The new two-step flow ends in a single `finishDriveSignIn()`, so the pending "change account" / "replace folder" state is consumed exactly once whichever step the flow ends at, and the account awaiting consent joins the rest of that state in the saved instance state. The foss stub keeps mirroring the signatures.
2. **Update com.google.android.gms:play-services-auth to 22.0.0** — one line, now that nothing removed is used.
3. **guide: describe the new Drive authorization flow** — usage.md described a single sign-in dialog.

No user-visible feature change, so I left `news.md` alone; happy to add a line if you'd rather have one.

## Verified

`./gradlew build test` green for both flavors (`-Werror` and `lint` included), ktlint clean.

On a Play Store emulator, gplay debug build, against a real Google account:

- **First-time path** — Drive access revoked first (`AuthorizationClient.revokeAccess`), then: picker → consent screen ("… wants access to your Google Account", Drive appdata) → destination added → "Back up now" uploaded to the appDataFolder.
- **Already-authorized path** — picker → no consent screen → destination added, `Restore backup` / `Delete backup` correctly offered, i.e. `hasBackup()` made a real Drive call with a working token.
