### PR TITLE
manifest: give the preferences activity an explicit label

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,7 +49,9 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MainActivity" />
         </activity>
-        <activity android:name=".PreferencesActivity" />
+        <activity
+            android:name=".PreferencesActivity"
+            android:label="@string/settings" />
         <activity
             android:name=".HealthConnectRationaleActivity"
             android:exported="true">


### PR DESCRIPTION
The default label was the app name, while other activities have a
dedicated label.

Related to <https://github.com/vmiklos/plees-tracker/issues/608>.
