### PR TITLE
preferences activity: add a back button to the action bar

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,7 +51,11 @@
         </activity>
         <activity
             android:name=".PreferencesActivity"
-            android:label="@string/settings" />
+            android:label="@string/settings">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
+        </activity>
         <activity
             android:name=".HealthConnectRationaleActivity"
             android:exported="true">

--- a/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
+++ b/app/src/main/java/hu/vmiklos/plees_tracker/PreferencesActivity.kt
@@ -13,6 +13,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import android.view.MenuItem
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
@@ -146,7 +147,18 @@ class PreferencesActivity : AppCompatActivity() {
 
         DataModel.handleWindowInsets(this)
 
+        // Show a back button.
+        actionBar?.setDisplayHomeAsUpEnabled(true)
+
         DataModel.preferencesActivity = this
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            this.finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
     }
 
     fun requestHealthConnectPermission() {

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -3,6 +3,8 @@
 ## master
 
 - Add optional Health Connect synchronization for sleep sessions. (Aozora7)
+- Resolves: gh#608 preferences activity: fixed the label and back button in its inconsistent action
+  bar
 
 ## 26.8
 


### PR DESCRIPTION
Similar to show the graphs, sleep and stats activity had one already.

Fixes <https://github.com/vmiklos/plees-tracker/issues/608>.
